### PR TITLE
Add configurable Dragon Warrior battle simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Dragon Warrior Battle Simulator
+
+This project provides a lightweight JavaScript simulator inspired by the NES game **Dragon Warrior**. Hero and monster statistics are fully configurable, allowing experimentation with arbitrary encounters.
+
+## Features
+- Monster ambushes determined by comparing `hero agility * rand(0-255)` with `enemy agility * 0.25 * rand(0-255)`.
+- Turn order determined by agility each round.
+- Supports hero spells HURT, HURTMORE, HEAL, and HEALMORE with per-spell MP costs and enemy resistance to HURT-category magic.
+- Tracks MP spent by the hero across a battle.
+- Hero picks the offensive action (attack, HURT, or HURTMORE) with the highest expected damage.
+- Enemies have a configurable chance to dodge attacks (default 2/64).
+- Tracks total battle time in frames (60 frames = 1 second) using default action timings:
+  - Hero attack: 120 frames
+  - Hero spell: 180 frames
+  - Enemy attack: 150 frames
+  - Enemy spell: 170 frames
+  - Enemy breath: 160 frames
+  - Enemy dodge: 60 frames when a dodge occurs
+- Fixed overhead for battles: 140-frame pre-battle animation and 200-frame post-battle message
+- Monster support abilities (Sleep, Stopspell, Heal, Healmore) with configurable likelihood each turn. Sleep causes the hero to skip turns with a 50% chance to wake starting the second turn; Stopspell can silence hero spellcasting.
+- Monsters can also have an attack ability (HURT, HURTMORE, Small Breath, Big Breath) used with a configurable frequency. Hero armor (None, Magic Armor, Erdrick's Armor) determines mitigation: Magic Armor reduces HURT spells while Erdrick's Armor also mitigates breath attacks and grants Stopspell immunity.
+- Heroes can cast STOPSPELL to silence enemy spellcasting based on the monster's Stopspell resistance (0–15 out of 16). Stopspelled monsters still attempt to cast but their spells fail and cost 60 fewer frames than normal.
+- When fighting the Golem, the hero can optionally carry the Fairy Flute. Playing it (480 frames) puts the Golem to sleep for one guaranteed turn and gives it a 33% wake chance on later turns.
+- Computes experience gained, average battle duration, and XP per minute.
+- Browser interface for quick experimentation and a CLI example.
+- Web UI includes preset enemy selector with stats; enemy HP is randomized each fight between 75% and 100% of its listed maximum.
+
+## Usage
+### Browser
+Open `index.html` in any modern browser. Adjust the hero, monster, and simulation settings and click **Simulate** to see win rate, XP per minute, average battle time, and MP usage along with a sample battle log.
+
+### Command line
+Run the test suite:
+
+```bash
+npm test
+```
+
+To execute the sample simulation CLI:
+
+```bash
+npm run cli
+```

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,45 @@
+import { simulateMany } from './simulator.js';
+
+const hero = {
+  hp: 100,
+  attack: 50,
+  defense: 40,
+  agility: 30,
+  mp: 50,
+  spells: ['HURT', 'HEAL', 'STOPSPELL'],
+  armor: 'none',
+  fairyFlute: true,
+};
+const monster = {
+  name: 'Golem',
+  hp: 80,
+  attack: 40,
+  defense: 30,
+  agility: 20,
+  xp: 120,
+  hurtResist: 4 / 16,
+  dodge: 2,
+  stopspellResist: 8 / 16,
+  supportAbility: 'sleep',
+  supportChance: 0.25,
+  attackAbility: 'hurt',
+  attackChance: 0.25,
+};
+const settings = {
+  preBattleTime: 140,
+  postBattleTime: 200,
+  heroAttackTime: 120,
+  heroSpellTime: 180,
+  enemyAttackTime: 150,
+  enemySpellTime: 170,
+  enemyBreathTime: 160,
+  enemyDodgeTime: 60,
+};
+
+const { winRate, averageXPPerMinute, averageMPSpent, averageTimeSeconds } =
+  simulateMany(hero, monster, settings, 100);
+
+console.log(`Win Rate: ${(winRate * 100).toFixed(2)}%`);
+console.log(`Average XP per minute: ${averageXPPerMinute.toFixed(2)}`);
+console.log(`Average MP spent per battle: ${averageMPSpent.toFixed(2)}`);
+console.log(`Average battle time (s): ${averageTimeSeconds.toFixed(2)}`);

--- a/enemies.json
+++ b/enemies.json
@@ -1,0 +1,344 @@
+[
+  {
+    "hp": 2,
+    "name": "Slime",
+    "attack": 5,
+    "defense": 1,
+    "agility": 3,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 3,
+    "name": "Red Slime",
+    "attack": 7,
+    "defense": 1,
+    "agility": 3,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 5,
+    "name": "Drakee",
+    "attack": 9,
+    "defense": 3,
+    "agility": 6,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 3,
+    "name": "Metal Slime",
+    "attack": 10,
+    "defense": 127,
+    "agility": 255,
+    "hurtResist": 15,
+    "dodge": 2
+  },
+  {
+    "hp": 7,
+    "name": "Ghost",
+    "attack": 11,
+    "defense": 4,
+    "agility": 8,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 12,
+    "name": "Magician",
+    "attack": 11,
+    "defense": 6,
+    "agility": 12,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 13,
+    "name": "Magidrakee",
+    "attack": 14,
+    "defense": 7,
+    "agility": 14,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 13,
+    "name": "Scorpion",
+    "attack": 18,
+    "defense": 8,
+    "agility": 16,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 23,
+    "name": "Poltergeist",
+    "attack": 18,
+    "defense": 10,
+    "agility": 20,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 22,
+    "name": "Druin",
+    "attack": 20,
+    "defense": 9,
+    "agility": 18,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 16,
+    "name": "Drakeema",
+    "attack": 22,
+    "defense": 13,
+    "agility": 26,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 20,
+    "name": "Droll",
+    "attack": 24,
+    "defense": 12,
+    "agility": 24,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 24,
+    "name": "Skeleton",
+    "attack": 28,
+    "defense": 11,
+    "agility": 22,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 28,
+    "name": "Warlock",
+    "attack": 28,
+    "defense": 11,
+    "agility": 22,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 18,
+    "name": "Metal Scorpion",
+    "attack": 36,
+    "defense": 21,
+    "agility": 42,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 33,
+    "name": "Wolf",
+    "attack": 40,
+    "defense": 15,
+    "agility": 30,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 33,
+    "name": "Specter",
+    "attack": 40,
+    "defense": 19,
+    "agility": 38,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 39,
+    "name": "Wraith",
+    "attack": 44,
+    "defense": 17,
+    "agility": 34,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 35,
+    "name": "Druinlord",
+    "attack": 47,
+    "defense": 20,
+    "agility": 40,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 50,
+    "name": "***Goldman",
+    "attack": 48,
+    "defense": 20,
+    "agility": 40,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 37,
+    "name": "Wolflord",
+    "attack": 50,
+    "defense": 18,
+    "agility": 36,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 44,
+    "name": "Drollmagi",
+    "attack": 52,
+    "defense": 25,
+    "agility": 50,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 37,
+    "name": "***Wyvern",
+    "attack": 56,
+    "defense": 24,
+    "agility": 48,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 40,
+    "name": "***Rogue Scorpion",
+    "attack": 60,
+    "defense": 45,
+    "agility": 90,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 40,
+    "name": "***Wraith Knight",
+    "attack": 68,
+    "defense": 28,
+    "agility": 56,
+    "hurtResist": 3,
+    "dodge": 2
+  },
+  {
+    "hp": 47,
+    "name": "***Knight",
+    "attack": 76,
+    "defense": 39,
+    "agility": 78,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 48,
+    "name": "***Magiwyvern",
+    "attack": 78,
+    "defense": 34,
+    "agility": 68,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 38,
+    "name": "***Demon Knight",
+    "attack": 79,
+    "defense": 32,
+    "agility": 64,
+    "hurtResist": 15,
+    "dodge": 2
+  },
+  {
+    "hp": 65,
+    "name": "***Wizard",
+    "attack": 80,
+    "defense": 35,
+    "agility": 70,
+    "hurtResist": 15,
+    "dodge": 2
+  },
+  {
+    "hp": 70,
+    "name": "***Werewolf",
+    "attack": 86,
+    "defense": 35,
+    "agility": 70,
+    "hurtResist": 0,
+    "dodge": 2
+  },
+  {
+    "hp": 74,
+    "name": "***Starwyvern",
+    "attack": 86,
+    "defense": 40,
+    "agility": 80,
+    "hurtResist": 1,
+    "dodge": 2
+  },
+  {
+    "hp": 72,
+    "name": "***Green Dragon",
+    "attack": 88,
+    "defense": 37,
+    "agility": 74,
+    "hurtResist": 2,
+    "dodge": 2
+  },
+  {
+    "hp": 67,
+    "name": "Axe Knight",
+    "attack": 94,
+    "defense": 41,
+    "agility": 82,
+    "hurtResist": 1,
+    "dodge": 2
+  },
+  {
+    "hp": 98,
+    "name": "Blue Dragon",
+    "attack": 98,
+    "defense": 42,
+    "agility": 84,
+    "hurtResist": 7,
+    "dodge": 2
+  },
+  {
+    "hp": 135,
+    "name": "Stoneman",
+    "attack": 100,
+    "defense": 20,
+    "agility": 40,
+    "hurtResist": 7,
+    "dodge": 2
+  },
+  {
+    "hp": 99,
+    "name": "Armored Knight",
+    "attack": 105,
+    "defense": 43,
+    "agility": 86,
+    "hurtResist": 1,
+    "dodge": 2
+  },
+  {
+    "hp": 153,
+    "name": "Golem",
+    "attack": 120,
+    "defense": 30,
+    "agility": 60,
+    "hurtResist": 15,
+    "dodge": 2
+  },
+  {
+    "hp": 106,
+    "name": "Red Dragon",
+    "attack": 120,
+    "defense": 45,
+    "agility": 90,
+    "hurtResist": 15,
+    "dodge": 2
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dragon Warrior Battle Simulator</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    fieldset { margin-bottom: 15px; }
+    label { display: block; margin-top: 5px; }
+  </style>
+</head>
+<body>
+  <h1>Dragon Warrior Battle Simulator</h1>
+  <form id="sim-form">
+    <fieldset>
+      <legend>Hero Stats</legend>
+      <label>HP <input type="number" id="hero-hp" value="100" /></label>
+      <label>Attack <input type="number" id="hero-attack" value="50" /></label>
+      <label>Defense <input type="number" id="hero-defense" value="40" /></label>
+      <label>Agility <input type="number" id="hero-agility" value="30" /></label>
+      <label>MP <input type="number" id="hero-mp" value="50" /></label>
+      <label><input type="checkbox" id="hero-hurt" /> HURT</label>
+      <label><input type="checkbox" id="hero-hurtmore" /> HURTMORE</label>
+      <label><input type="checkbox" id="hero-heal" /> HEAL</label>
+      <label><input type="checkbox" id="hero-healmore" /> HEALMORE</label>
+      <label><input type="checkbox" id="hero-stopspell" /> STOPSPELL</label>
+      <label>Armor
+        <select id="hero-armor">
+          <option value="none">None</option>
+          <option value="magic">Magic Armor</option>
+          <option value="erdrick">Erdrick's Armor</option>
+        </select>
+      </label>
+      <label id="flute-option" style="display:none"><input type="checkbox" id="hero-flute" /> Fairy Flute</label>
+    </fieldset>
+    <fieldset>
+      <legend>Monster Stats</legend>
+      <label>Enemy
+        <select id="enemy-select"></select>
+      </label>
+      <label>HP <input type="number" id="mon-hp" value="80" /></label>
+      <label>Attack <input type="number" id="mon-attack" value="40" /></label>
+      <label>Defense <input type="number" id="mon-defense" value="30" /></label>
+      <label>Agility <input type="number" id="mon-agility" value="20" /></label>
+      <label>XP Reward <input type="number" id="mon-xp" value="120" /></label>
+      <label>HURT Resist (0-15) <input type="number" id="hurt-resist" value="0" /></label>
+      <label>Stopspell Resist (0-15)
+        <select id="stopspell-resist">
+          <option value="0">0</option>
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+          <option value="8">8</option>
+          <option value="9">9</option>
+          <option value="10">10</option>
+          <option value="11">11</option>
+          <option value="12">12</option>
+          <option value="13">13</option>
+          <option value="14">14</option>
+          <option value="15">15</option>
+        </select>
+      </label>
+      <label>Dodge (0-64) <input type="number" id="mon-dodge" value="2" /></label>
+      <label>Support Ability
+        <select id="mon-support">
+          <option value="">None</option>
+          <option value="sleep">Sleep</option>
+          <option value="stopspell">Stopspell</option>
+          <option value="heal">Heal</option>
+          <option value="healmore">Healmore</option>
+        </select>
+      </label>
+      <label>Support Chance
+        <select id="mon-support-chance">
+          <option value="0.25">25%</option>
+          <option value="0.5">50%</option>
+          <option value="0.75">75%</option>
+        </select>
+      </label>
+      <label>Attack Ability
+        <select id="mon-attack-ability">
+          <option value="">None</option>
+          <option value="hurt">HURT</option>
+          <option value="hurtmore">HURTMORE</option>
+          <option value="smallbreath">Small Breath</option>
+          <option value="bigbreath">Big Breath</option>
+        </select>
+      </label>
+      <label>Attack Chance
+        <select id="mon-attack-chance">
+          <option value="0.25">25%</option>
+          <option value="0.5">50%</option>
+          <option value="0.75">75%</option>
+        </select>
+      </label>
+    </fieldset>
+    <fieldset>
+      <legend>Simulation Settings</legend>
+      <label>Hero Attack Time (frames) <input type="number" id="hero-attack-time" value="120" /></label>
+      <label>Hero Spell Time (frames) <input type="number" id="hero-spell-time" value="180" /></label>
+      <label>Enemy Attack Time (frames) <input type="number" id="enemy-attack-time" value="150" /></label>
+      <label>Enemy Spell Time (frames) <input type="number" id="enemy-spell-time" value="170" /></label>
+      <label>Enemy Breath Time (frames) <input type="number" id="enemy-breath-time" value="160" /></label>
+      <label>Enemy Dodge Time (frames) <input type="number" id="enemy-dodge-time" value="60" /></label>
+      <label>Pre-Battle Time (frames) <input type="number" id="pre-battle-time" value="140" /></label>
+      <label>Post-Battle Time (frames) <input type="number" id="post-battle-time" value="200" /></label>
+      <label>Iterations <input type="number" id="iterations" value="100" /></label>
+    </fieldset>
+    <button type="submit">Simulate</button>
+  </form>
+  <pre id="results"></pre>
+
+  <script type="module">
+    import { simulateMany, simulateBattle } from './simulator.js';
+
+    const form = document.getElementById('sim-form');
+    const results = document.getElementById('results');
+    const enemySelect = document.getElementById('enemy-select');
+
+    let enemies = [];
+    fetch('./enemies.json')
+      .then((r) => r.json())
+      .then((data) => {
+        enemies = data;
+        enemySelect.appendChild(new Option('Custom', ''));
+        for (const e of enemies) {
+          enemySelect.appendChild(new Option(e.name.replace(/\*/g, ''), e.name));
+        }
+      });
+
+    enemySelect.addEventListener('change', () => {
+      const chosen = enemies.find((e) => e.name === enemySelect.value);
+      const cleanName = (enemySelect.value || '').replace(/\*/g, '');
+      document.getElementById('flute-option').style.display =
+        cleanName === 'Golem' ? 'block' : 'none';
+      if (!chosen) return;
+      document.getElementById('mon-hp').value = chosen.hp;
+      document.getElementById('mon-attack').value = chosen.attack;
+      document.getElementById('mon-defense').value = chosen.defense;
+      document.getElementById('mon-agility').value = chosen.agility;
+      document.getElementById('hurt-resist').value = chosen.hurtResist;
+      document.getElementById('mon-dodge').value = chosen.dodge ?? 2;
+      document.getElementById('stopspell-resist').value = chosen.stopspellResist ?? 0;
+    });
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const hero = {
+        hp: Number(document.getElementById('hero-hp').value),
+        attack: Number(document.getElementById('hero-attack').value),
+        defense: Number(document.getElementById('hero-defense').value),
+        agility: Number(document.getElementById('hero-agility').value),
+        mp: Number(document.getElementById('hero-mp').value),
+        armor: document.getElementById('hero-armor').value,
+        fairyFlute: document.getElementById('hero-flute').checked,
+        spells: [
+          ...(document.getElementById('hero-hurt').checked ? ['HURT'] : []),
+          ...(document.getElementById('hero-hurtmore').checked ? ['HURTMORE'] : []),
+          ...(document.getElementById('hero-heal').checked ? ['HEAL'] : []),
+          ...(document.getElementById('hero-healmore').checked ? ['HEALMORE'] : []),
+          ...(document.getElementById('hero-stopspell').checked ? ['STOPSPELL'] : []),
+        ],
+      };
+      const monster = {
+        name: (enemySelect.value || 'Custom').replace(/\*/g, ''),
+        hp: Number(document.getElementById('mon-hp').value),
+        attack: Number(document.getElementById('mon-attack').value),
+        defense: Number(document.getElementById('mon-defense').value),
+        agility: Number(document.getElementById('mon-agility').value),
+        xp: Number(document.getElementById('mon-xp').value),
+        hurtResist: Number(document.getElementById('hurt-resist').value) / 16,
+        dodge: Number(document.getElementById('mon-dodge').value),
+        stopspellResist: Number(document.getElementById('stopspell-resist').value) / 16,
+        supportAbility: document.getElementById('mon-support').value,
+        supportChance: Number(document.getElementById('mon-support-chance').value),
+        attackAbility: document.getElementById('mon-attack-ability').value,
+        attackChance: Number(document.getElementById('mon-attack-chance').value),
+      };
+      const settings = {
+        heroAttackTime: Number(document.getElementById('hero-attack-time').value),
+        heroSpellTime: Number(document.getElementById('hero-spell-time').value),
+        enemyAttackTime: Number(document.getElementById('enemy-attack-time').value),
+        enemySpellTime: Number(document.getElementById('enemy-spell-time').value),
+        enemyBreathTime: Number(document.getElementById('enemy-breath-time').value),
+        enemyDodgeTime: Number(document.getElementById('enemy-dodge-time').value),
+        preBattleTime: Number(document.getElementById('pre-battle-time').value),
+        postBattleTime: Number(document.getElementById('post-battle-time').value),
+      };
+      const iterations = Number(document.getElementById('iterations').value);
+
+      const summary = simulateMany(hero, monster, settings, iterations);
+      const hpMax = monster.hp;
+      const hpMin = Math.ceil(hpMax * 0.75);
+      const exampleMonster = {
+        ...monster,
+        hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
+      };
+      const example = simulateBattle(hero, exampleMonster, settings);
+
+      results.textContent =
+        `Win Rate: ${(summary.winRate * 100).toFixed(2)}%\n` +
+        `Average XP per minute: ${summary.averageXPPerMinute.toFixed(2)}\n` +
+        `Average MP spent per battle: ${summary.averageMPSpent.toFixed(2)}\n` +
+        `Average battle time (s): ${summary.averageTimeSeconds.toFixed(2)}\n\n` +
+        `Sample Battle (MP Spent: ${example.mpSpent})\n` +
+        example.log.join('\n');
+    });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dwr-battle-sim",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node tests.js",
+    "cli": "node cli.js"
+  }
+}

--- a/simulator.js
+++ b/simulator.js
@@ -1,0 +1,420 @@
+export function computeDamage(attacker, defender, rng = Math.random) {
+  const maxDamage = Math.max(0, (attacker.attack - defender.defense) / 2);
+  const minQ = Math.floor((maxDamage / 2) * 4);
+  const maxQ = Math.floor(maxDamage * 4);
+  const roll = minQ + Math.floor(rng() * (maxQ - minQ + 1));
+  const dmg = Math.floor(roll / 4);
+  return Math.max(0, dmg);
+}
+
+function averagePhysicalDamage(attacker, defender) {
+  const maxDamage = Math.max(0, (attacker.attack - defender.defense) / 2);
+  const minQ = Math.floor((maxDamage / 2) * 4);
+  const maxQ = Math.floor(maxDamage * 4);
+  let total = 0;
+  for (let q = minQ; q <= maxQ; q++) {
+    total += Math.floor(q / 4);
+  }
+  const count = maxQ - minQ + 1;
+  return count > 0 ? total / count : 0;
+}
+
+function castHurtSpell(name, resist) {
+  const resisted = Math.random() < resist;
+  if (resisted) return 0;
+  if (name === 'HURTMORE') {
+    return 58 + Math.floor(Math.random() * 8); // 58-65
+  }
+  return 9 + Math.floor(Math.random() * 8); // HURT: 9-16
+}
+
+function castHealSpell(name) {
+  if (name === 'HEALMORE') {
+    return 85 + Math.floor(Math.random() * 16); // 85-100
+  }
+  return 18 + Math.floor(Math.random() * 8); // HEAL: 18-25
+}
+
+export function castBreathAttack(kind, rng = Math.random) {
+  if (kind === 'big') {
+    return 65 + Math.floor(rng() * 8); // 65-72
+  }
+  return 22 + Math.floor(rng() * 9); // 22-30
+}
+
+export function mitigateDamage(dmg) {
+  return Math.floor(dmg / 3) * 2;
+}
+
+const HERO_SPELL_COST = {
+  HURT: 2,
+  HURTMORE: 5,
+  HEAL: 3,
+  HEALMORE: 8,
+  STOPSPELL: 2,
+};
+
+export function simulateBattle(heroStats, monsterStats, settings = {}) {
+  const {
+    heroAttackTime = 120,
+    heroSpellTime = 180,
+    enemyAttackTime = 150,
+    enemySpellTime = 170,
+    enemyBreathTime = 160,
+    enemyDodgeTime = 60,
+    preBattleTime = 140,
+    postBattleTime = 200,
+  } = settings;
+
+  let log = [];
+  let timeFrames = preBattleTime;
+  let rounds = 0;
+  let mpSpent = 0;
+
+  const armor = heroStats.armor || 'none';
+  const hero = {
+    ...heroStats,
+    armor,
+    mp: heroStats.mp ?? 0,
+    maxHp: heroStats.hp,
+    stopspelled: false,
+    asleep: false,
+    sleepTurns: 0,
+    fairyFlute: heroStats.fairyFlute || false,
+  };
+  hero.hurtMitigation = armor === 'magic' || armor === 'erdrick';
+  hero.breathMitigation = armor === 'erdrick';
+  hero.stopspellImmune = armor === 'erdrick';
+  const monster = { ...monsterStats };
+  monster.dodge = monster.dodge ?? 2;
+  monster.maxHp = monster.maxHp ?? monster.hp;
+  monster.asleep = false;
+  monster.sleepTurns = 0;
+  monster.stopspelled = monster.stopspelled || false;
+  monster.stopspellResist = monster.stopspellResist || 0;
+  let monsterMaxDamage = Math.floor(Math.max(0, (monster.attack - hero.defense) / 2));
+  if (monster.attackAbility) {
+    let abilityMax = 0;
+    switch (monster.attackAbility) {
+      case 'hurt':
+        abilityMax = 16;
+        if (hero.hurtMitigation) abilityMax = mitigateDamage(abilityMax);
+        break;
+      case 'hurtmore':
+        abilityMax = 65;
+        if (hero.hurtMitigation) abilityMax = mitigateDamage(abilityMax);
+        break;
+      case 'smallbreath':
+        abilityMax = 30;
+        if (hero.breathMitigation) abilityMax = mitigateDamage(abilityMax);
+        break;
+      case 'bigbreath':
+        abilityMax = 72;
+        if (hero.breathMitigation) abilityMax = mitigateDamage(abilityMax);
+        break;
+    }
+    monsterMaxDamage = Math.max(monsterMaxDamage, abilityMax);
+  }
+
+  const heroRoll = hero.agility * Math.floor(Math.random() * 256);
+  const enemyRoll = monster.agility * 0.25 * Math.floor(Math.random() * 256);
+  if (heroRoll < enemyRoll) {
+    const dmg = computeDamage(monster, hero);
+    hero.hp -= dmg;
+    timeFrames += enemyAttackTime;
+    log.push(`Monster ambushes for ${dmg} damage!`);
+    if (hero.hp <= 0) {
+      timeFrames += postBattleTime;
+      const timeSeconds = timeFrames / 60;
+      return {
+        winner: 'monster',
+        rounds,
+        timeFrames,
+        timeSeconds,
+        xpGained: 0,
+        xpPerMinute: 0,
+        log,
+      };
+    }
+  }
+
+  function determineHeroAction() {
+    if (hero.fairyFlute && monster.name === 'Golem' && !monster.asleep) {
+      return 'FAIRY_FLUTE';
+    }
+    if (hero.stopspelled) return 'attack';
+    if (hero.spells) {
+      let currentMaxDamage = monsterMaxDamage;
+      if (
+        monster.stopspelled &&
+        (monster.attackAbility === 'hurt' || monster.attackAbility === 'hurtmore')
+      ) {
+        currentMaxDamage = Math.floor(Math.max(0, (monster.attack - hero.defense) / 2));
+      }
+      if (hero.hp <= currentMaxDamage) {
+        if (hero.spells.includes('HEALMORE') && hero.mp >= HERO_SPELL_COST.HEALMORE)
+          return 'HEALMORE';
+        if (hero.spells.includes('HEAL') && hero.mp >= HERO_SPELL_COST.HEAL)
+          return 'HEAL';
+      }
+      if (
+        hero.spells.includes('STOPSPELL') &&
+        hero.mp >= HERO_SPELL_COST.STOPSPELL &&
+        !monster.stopspelled &&
+        (monster.supportAbility || monster.attackAbility === 'hurt' || monster.attackAbility === 'hurtmore')
+      ) {
+        return 'STOPSPELL';
+      }
+      let best = 'attack';
+      let bestDamage = averagePhysicalDamage(hero, monster);
+      if (hero.spells.includes('HURTMORE') && hero.mp >= HERO_SPELL_COST.HURTMORE) {
+        const avg = 61.5 * (1 - (monster.hurtResist || 0));
+        if (avg > bestDamage) {
+          bestDamage = avg;
+          best = 'HURTMORE';
+        }
+      }
+      if (hero.spells.includes('HURT') && hero.mp >= HERO_SPELL_COST.HURT) {
+        const avg = 12.5 * (1 - (monster.hurtResist || 0));
+        if (avg > bestDamage) {
+          bestDamage = avg;
+          best = 'HURT';
+        }
+      }
+      return best;
+    }
+    return 'attack';
+  }
+
+  function runHeroTurn() {
+    if (hero.asleep) {
+      if (hero.sleepTurns >= 1 && Math.random() < 0.5) {
+        hero.asleep = false;
+        hero.sleepTurns = 0;
+      } else {
+        timeFrames += 60;
+        hero.sleepTurns++;
+        log.push('Hero is asleep.');
+        return;
+      }
+    }
+
+    const action = determineHeroAction();
+    if (action === 'FAIRY_FLUTE') {
+      monster.asleep = true;
+      monster.sleepTurns = 0;
+      timeFrames += 480;
+      log.push('Hero plays the Fairy Flute!');
+      return;
+    }
+    if (action === 'STOPSPELL') {
+      const success = Math.random() < (monster.stopspellResist || 0);
+      hero.mp -= HERO_SPELL_COST.STOPSPELL;
+      mpSpent += HERO_SPELL_COST.STOPSPELL;
+      timeFrames += heroSpellTime;
+      if (success) {
+        monster.stopspelled = true;
+        log.push('Hero casts STOPSPELL. Monster is affected.');
+      } else {
+        log.push('Hero casts STOPSPELL, but it fails.');
+      }
+      return;
+    }
+    if (action === 'HURTMORE' || action === 'HURT') {
+      const dmg = castHurtSpell(action, monster.hurtResist || 0);
+      monster.hp -= dmg;
+      hero.mp -= HERO_SPELL_COST[action];
+      mpSpent += HERO_SPELL_COST[action];
+      timeFrames += heroSpellTime;
+      log.push(
+        dmg > 0
+          ? `Hero casts ${action} for ${dmg} damage.`
+          : `Monster resists ${action}.`
+      );
+      return;
+    }
+    if (action === 'HEAL' || action === 'HEALMORE') {
+      const heal = castHealSpell(action);
+      hero.hp = Math.min(hero.hp + heal, hero.maxHp);
+      hero.mp -= HERO_SPELL_COST[action];
+      mpSpent += HERO_SPELL_COST[action];
+      timeFrames += heroSpellTime;
+      log.push(`Hero casts ${action} and heals ${heal} HP.`);
+      return;
+    }
+
+    const dodgeChance = (monster.dodge || 0) / 64;
+    if (Math.random() < dodgeChance) {
+      timeFrames += enemyDodgeTime;
+      log.push('Monster dodges the attack!');
+    } else {
+      const dmg = computeDamage(hero, monster);
+      monster.hp -= dmg;
+      timeFrames += heroAttackTime;
+      log.push(`Hero attacks for ${dmg} damage.`);
+    }
+  }
+
+  function runMonsterTurn() {
+    if (monster.asleep) {
+      if (monster.sleepTurns === 0) {
+        timeFrames += 60;
+        monster.sleepTurns++;
+        log.push('Golem is asleep.');
+        return;
+      }
+      if (Math.random() < 1 / 3) {
+        monster.asleep = false;
+        monster.sleepTurns = 0;
+        log.push('Golem wakes up.');
+      } else {
+        timeFrames += 60;
+        monster.sleepTurns++;
+        log.push('Golem is asleep.');
+        return;
+      }
+    }
+    if (monster.supportAbility) {
+      let useSupport = Math.random() < (monster.supportChance || 0);
+      if (monster.supportAbility === 'sleep' && hero.asleep) useSupport = false;
+      if (monster.supportAbility === 'stopspell' && hero.stopspelled) useSupport = false;
+      if (
+        (monster.supportAbility === 'heal' || monster.supportAbility === 'healmore') &&
+        monster.hp < monster.maxHp / 4
+      ) {
+        useSupport = false;
+      }
+      if (useSupport) {
+        if (monster.stopspelled) {
+          timeFrames += enemySpellTime - 60;
+          log.push(
+            `Monster tries to cast ${monster.supportAbility.toUpperCase()}, but is stopspelled.`
+          );
+          return;
+        }
+        if (monster.supportAbility === 'sleep') {
+          hero.asleep = true;
+          hero.sleepTurns = 0;
+          timeFrames += enemySpellTime;
+          log.push('Monster casts SLEEP.');
+          return;
+        }
+        if (monster.supportAbility === 'stopspell') {
+          timeFrames += enemySpellTime;
+          log.push('Monster casts STOPSPELL.');
+          if (!hero.stopspellImmune && Math.random() < 0.5) {
+            hero.stopspelled = true;
+            log.push('Hero is affected by STOPSPELL.');
+          } else {
+            log.push('But nothing happens.');
+          }
+          return;
+        }
+        if (monster.supportAbility === 'heal' || monster.supportAbility === 'healmore') {
+          const heal = castHealSpell(monster.supportAbility.toUpperCase());
+          monster.hp = Math.min(monster.hp + heal, monster.maxHp);
+          timeFrames += enemySpellTime;
+          log.push(
+            `Monster casts ${monster.supportAbility.toUpperCase()} and heals ${heal} HP.`
+          );
+          return;
+        }
+      }
+    }
+
+    if (monster.attackAbility && Math.random() < (monster.attackChance || 0)) {
+      let dmg = 0;
+      if (monster.attackAbility === 'hurt' || monster.attackAbility === 'hurtmore') {
+        const spell = monster.attackAbility.toUpperCase();
+        if (monster.stopspelled) {
+          timeFrames += enemySpellTime - 60;
+          log.push(`Monster tries to cast ${spell}, but is stopspelled.`);
+        } else {
+          dmg = castHurtSpell(spell);
+          if (hero.hurtMitigation) dmg = mitigateDamage(dmg);
+          hero.hp -= dmg;
+          timeFrames += enemySpellTime;
+          log.push(`Monster casts ${spell} for ${dmg} damage.`);
+        }
+        return;
+      }
+      if (monster.attackAbility === 'smallbreath' || monster.attackAbility === 'bigbreath') {
+        const kind = monster.attackAbility === 'smallbreath' ? 'small' : 'big';
+        dmg = castBreathAttack(kind);
+        if (hero.breathMitigation) dmg = mitigateDamage(dmg);
+        hero.hp -= dmg;
+        timeFrames += enemyBreathTime;
+        log.push(
+          `Monster uses ${monster.attackAbility === 'smallbreath' ? 'SMALL BREATH' : 'BIG BREATH'} for ${dmg} damage.`
+        );
+        return;
+      }
+    }
+    const dmg = computeDamage(monster, hero);
+    hero.hp -= dmg;
+    timeFrames += enemyAttackTime;
+    log.push(`Monster attacks for ${dmg} damage.`);
+  }
+
+  function turnOrder() {
+    return hero.agility >= monster.agility ? ['hero', 'monster'] : ['monster', 'hero'];
+  }
+
+  while (hero.hp > 0 && monster.hp > 0) {
+    rounds++;
+    for (const actor of turnOrder()) {
+      if (actor === 'hero') {
+        runHeroTurn();
+      } else {
+        runMonsterTurn();
+      }
+      if (hero.hp <= 0 || monster.hp <= 0) break;
+    }
+  }
+
+  timeFrames += postBattleTime;
+  const winner = hero.hp > 0 ? 'hero' : 'monster';
+  const xpGained = winner === 'hero' ? monsterStats.xp : 0;
+  const timeSeconds = timeFrames / 60;
+  const xpPerMinute = xpGained * 60 / timeSeconds;
+
+  return {
+    winner,
+    rounds,
+    timeFrames,
+    timeSeconds,
+    xpGained,
+    xpPerMinute,
+    mpSpent,
+    log,
+  };
+}
+
+export function simulateMany(hero, monster, settings = {}, iterations = 1) {
+  let totalXP = 0;
+  let totalFrames = 0;
+  let wins = 0;
+  let totalMP = 0;
+  for (let i = 0; i < iterations; i++) {
+    const hpMax = monster.hp;
+    const hpMin = Math.ceil(hpMax * 0.75);
+    const m = {
+      ...monster,
+      hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
+      maxHp: hpMax,
+    };
+    const result = simulateBattle(hero, m, settings);
+    totalXP += result.xpGained;
+    totalFrames += result.timeFrames;
+    totalMP += result.mpSpent;
+    if (result.winner === 'hero') wins++;
+  }
+  const averageXPPerMinute = totalFrames === 0 ? 0 : (totalXP * 3600) / totalFrames;
+  const averageTimeSeconds = totalFrames / iterations / 60;
+  return {
+    winRate: wins / iterations,
+    averageXPPerMinute,
+    averageMPSpent: totalMP / iterations,
+    averageTimeSeconds,
+  };
+}

--- a/tests.js
+++ b/tests.js
@@ -1,0 +1,125 @@
+import assert from 'node:assert';
+import {
+  computeDamage,
+  castBreathAttack,
+  mitigateDamage,
+  simulateBattle,
+  simulateMany,
+} from './simulator.js';
+
+function averageDamage(attacker, defender) {
+  const maxDamage = Math.max(0, (attacker.attack - defender.defense) / 2);
+  const minQ = Math.floor((maxDamage / 2) * 4);
+  const maxQ = Math.floor(maxDamage * 4);
+  const n = maxQ - minQ + 1;
+  let total = 0;
+  for (let i = 0; i < n; i++) {
+    const rng = () => (i + 0.5) / n;
+    total += computeDamage(attacker, defender, rng);
+  }
+  return total / n;
+}
+
+const avg = averageDamage({ attack: 130 }, { defense: 100 });
+assert(Math.abs(avg - 10.875) < 0.01);
+
+console.log('computeDamage average test passed');
+
+const counts = {};
+for (let i = 0; i < 8; i++) {
+  const rng = () => (i + 0.5) / 8;
+  const dmg = mitigateDamage(castBreathAttack('big', rng));
+  counts[dmg] = (counts[dmg] || 0) + 1;
+}
+assert.deepStrictEqual(counts, { 42: 1, 44: 3, 46: 3, 48: 1 });
+console.log('big breath mitigation distribution test passed');
+
+// Fairy Flute forces the Golem to sleep for one turn and gives a 33% wake chance afterward
+{
+  const seq = [0, 0, 0, 0.2, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 1,
+    attack: 0,
+    defense: 0,
+    agility: 50,
+    mp: 0,
+    armor: 'none',
+    fairyFlute: true,
+  };
+  const golem = { name: 'Golem', hp: 5, attack: 10, defense: 0, agility: 10, xp: 0 };
+  const result = simulateBattle(hero, golem);
+  Math.random = orig;
+  assert.strictEqual(result.log[0], 'Hero plays the Fairy Flute!');
+  assert(result.log.includes('Golem is asleep.'));
+  assert(result.log.includes('Golem wakes up.'));
+  console.log('fairy flute wake logic test passed');
+}
+
+// Stopspell prevents enemy spells and shortens their casting time by 60 frames
+{
+  const seq = [0, 0, 0, 0, 0.5];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 10,
+    attack: 100,
+    defense: 0,
+    agility: 50,
+    mp: 10,
+    spells: ['STOPSPELL'],
+    armor: 'none',
+  };
+  const monster = {
+    name: 'Mage',
+    hp: 25,
+    attack: 0,
+    defense: 0,
+    agility: 10,
+    xp: 0,
+    supportAbility: 'sleep',
+    supportChance: 1,
+    stopspellResist: 1 / 16,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 1,
+    heroSpellTime: 1,
+    enemySpellTime: 70,
+    enemyAttackTime: 1,
+    enemyBreathTime: 1,
+  });
+  Math.random = orig;
+  assert(result.log.includes('Hero casts STOPSPELL. Monster is affected.'));
+  assert(result.log.includes('Monster tries to cast SLEEP, but is stopspelled.'));
+  assert.strictEqual(result.timeFrames, 12);
+  console.log('stopspell logic test passed');
+}
+
+// simulateMany returns average battle time in seconds
+{
+  const hero = { hp: 10, attack: 100, defense: 0, agility: 10 };
+  const monster = { name: 'Slime', hp: 1, attack: 0, defense: 0, agility: 0, xp: 0 };
+  const summary = simulateMany(
+    hero,
+    monster,
+    {
+      preBattleTime: 0,
+      postBattleTime: 0,
+      heroAttackTime: 1,
+      heroSpellTime: 1,
+      enemyAttackTime: 1,
+      enemySpellTime: 1,
+      enemyBreathTime: 1,
+      enemyDodgeTime: 1,
+    },
+    1
+  );
+  assert(Math.abs(summary.averageTimeSeconds - 1 / 60) < 1e-9);
+  console.log('average time reporting test passed');
+}
+


### PR DESCRIPTION
## Summary
- Strip decorative asterisks from preset enemy names when populating the UI and before simulation
- Calculate and surface average battle duration in seconds in both the browser output and CLI
- Document the new average-time metric

## Testing
- `npm test`
- `npm run cli`


------
https://chatgpt.com/codex/tasks/task_e_6897cd27ffec83328bc76241a5c7b149