### PR TITLE
Fix monster healing threshold and cap healing to max HP

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -252,11 +252,12 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     }
     if (action === 'HEAL' || action === 'HEALMORE') {
       const heal = castHealSpell(action);
-      hero.hp = Math.min(hero.hp + heal, hero.maxHp);
+      const actual = Math.min(heal, hero.maxHp - hero.hp);
+      hero.hp += actual;
       hero.mp -= HERO_SPELL_COST[action];
       mpSpent += HERO_SPELL_COST[action];
       timeFrames += heroSpellTime;
-      log.push(`Hero casts ${action} and heals ${heal} HP.`);
+      log.push(`Hero casts ${action} and heals ${actual} HP.`);
       return;
     }
 
@@ -297,7 +298,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
       if (monster.supportAbility === 'stopspell' && hero.stopspelled) useSupport = false;
       if (
         (monster.supportAbility === 'heal' || monster.supportAbility === 'healmore') &&
-        monster.hp > monster.maxHp / 4
+        monster.hp >= monster.maxHp / 4
       ) {
         useSupport = false;
       }
@@ -329,10 +330,11 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
         }
         if (monster.supportAbility === 'heal' || monster.supportAbility === 'healmore') {
           const heal = castHealSpell(monster.supportAbility.toUpperCase());
-          monster.hp = Math.min(monster.hp + heal, monster.maxHp);
+          const actual = Math.min(heal, monster.maxHp - monster.hp);
+          monster.hp += actual;
           timeFrames += enemySpellTime;
           log.push(
-            `Monster casts ${monster.supportAbility.toUpperCase()} and heals ${heal} HP.`
+            `Monster casts ${monster.supportAbility.toUpperCase()} and heals ${actual} HP.`
           );
           return;
         }

--- a/tests.js
+++ b/tests.js
@@ -216,3 +216,106 @@ console.log('big breath mitigation distribution test passed');
   console.log('average time reporting test passed');
 }
 
+// Monsters only heal when below 25% HP and healing is capped
+{
+  const seq = [0, 0, 0, 0, 0, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = { hp: 10, attack: 0, defense: 0, agility: 10 };
+  const monster = {
+    name: 'Healer',
+    hp: 25,
+    maxHp: 100,
+    attack: 50,
+    defense: 0,
+    agility: 10,
+    xp: 0,
+    supportAbility: 'heal',
+    supportChance: 1,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 1,
+    heroSpellTime: 1,
+    enemyAttackTime: 1,
+    enemySpellTime: 1,
+    enemyBreathTime: 1,
+    enemyDodgeTime: 1,
+  });
+  Math.random = orig;
+  assert(!result.log.includes('Monster casts HEAL'));
+  console.log('monster heal threshold (no heal) test passed');
+}
+
+{
+  const seq = [0, 0, 0, 0, 0, 0.99, 0, 0, 0, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = { hp: 1, attack: 0, defense: 0, agility: 10 };
+  const monster = {
+    name: 'Healer',
+    hp: 20,
+    maxHp: 100,
+    attack: 50,
+    defense: 0,
+    agility: 10,
+    xp: 0,
+    supportAbility: 'healmore',
+    supportChance: 1,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 1,
+    heroSpellTime: 1,
+    enemyAttackTime: 1,
+    enemySpellTime: 1,
+    enemyBreathTime: 1,
+    enemyDodgeTime: 1,
+  });
+  Math.random = orig;
+  assert(result.log.includes('Monster casts HEALMORE and heals 80 HP.'));
+  console.log('monster heal threshold (heal and cap) test passed');
+}
+
+// Hero healing is capped at maximum HP
+{
+  const seq = [0, 0.5, 0, 0, 0.99];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 100,
+    attack: 0,
+    defense: 0,
+    agility: 0,
+    mp: 8,
+    spells: ['HEALMORE'],
+    armor: 'none',
+  };
+  const monster = {
+    name: 'BadGuy',
+    hp: 1,
+    attack: 300,
+    defense: 0,
+    agility: 1,
+    xp: 0,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 1,
+    heroSpellTime: 1,
+    enemyAttackTime: 1,
+    enemySpellTime: 1,
+    enemyBreathTime: 1,
+    enemyDodgeTime: 1,
+  });
+  Math.random = orig;
+  assert(result.log.includes('Hero casts HEALMORE and heals 75 HP.'));
+  console.log('hero heal cap test passed');
+}
+


### PR DESCRIPTION
## Summary
- Prevent monsters from casting healing spells unless below 25% HP
- Clamp all healing for hero and monsters to their maximum HP and log actual amount healed
- Add unit tests covering new healing behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689818720c688332a53789bbc4f7a5d5