### PR TITLE
Ensure preset stats populate all monster fields

### DIFF
--- a/enemies.json
+++ b/enemies.json
@@ -191,7 +191,7 @@
   },
   {
     "hp": 50,
-    "name": "***Goldman",
+    "name": "Goldman",
     "attack": 48,
     "defense": 20,
     "agility": 40,
@@ -221,7 +221,7 @@
   },
   {
     "hp": 37,
-    "name": "***Wyvern",
+    "name": "Wyvern",
     "attack": 56,
     "defense": 24,
     "agility": 48,
@@ -231,7 +231,7 @@
   },
   {
     "hp": 40,
-    "name": "***Rogue Scorpion",
+    "name": "Rogue Scorpion",
     "attack": 60,
     "defense": 45,
     "agility": 90,
@@ -241,7 +241,7 @@
   },
   {
     "hp": 40,
-    "name": "***Wraith Knight",
+    "name": "Wraith Knight",
     "attack": 68,
     "defense": 28,
     "agility": 56,
@@ -251,7 +251,7 @@
   },
   {
     "hp": 47,
-    "name": "***Knight",
+    "name": "Knight",
     "attack": 76,
     "defense": 39,
     "agility": 78,
@@ -261,7 +261,7 @@
   },
   {
     "hp": 48,
-    "name": "***Magiwyvern",
+    "name": "Magiwyvern",
     "attack": 78,
     "defense": 34,
     "agility": 68,
@@ -271,7 +271,7 @@
   },
   {
     "hp": 38,
-    "name": "***Demon Knight",
+    "name": "Demon Knight",
     "attack": 79,
     "defense": 32,
     "agility": 64,
@@ -281,7 +281,7 @@
   },
   {
     "hp": 65,
-    "name": "***Wizard",
+    "name": "Wizard",
     "attack": 80,
     "defense": 35,
     "agility": 70,
@@ -291,7 +291,7 @@
   },
   {
     "hp": 70,
-    "name": "***Werewolf",
+    "name": "Werewolf",
     "attack": 86,
     "defense": 35,
     "agility": 70,
@@ -301,7 +301,7 @@
   },
   {
     "hp": 74,
-    "name": "***Starwyvern",
+    "name": "Starwyvern",
     "attack": 86,
     "defense": 40,
     "agility": 80,
@@ -311,7 +311,7 @@
   },
   {
     "hp": 72,
-    "name": "***Green Dragon",
+    "name": "Green Dragon",
     "attack": 88,
     "defense": 37,
     "agility": 74,

--- a/index.html
+++ b/index.html
@@ -201,17 +201,22 @@
         enemies = data;
         enemySelect.appendChild(new Option('Custom', ''));
         for (const e of enemies) {
-          enemySelect.appendChild(new Option(e.name.replace(/\*/g, ''), e.name));
+          enemySelect.appendChild(new Option(e.name, e.name));
         }
         enemySelect.value = enemies[0]?.name || '';
+        if (usePreset.checked && enemies[0]) {
+          setMonsterStats(enemies[0]);
+        }
+        const selectedName = enemySelect.value || '';
+        document.getElementById('flute-option').style.display =
+          selectedName === 'Golem' ? 'block' : 'none';
         toggleMonsterStats();
-        enemySelect.dispatchEvent(new Event('change'));
       });
 
     enemySelect.addEventListener('change', () => {
-      const cleanName = (enemySelect.value || '').replace(/\*/g, '');
+      const selectedName = enemySelect.value || '';
       document.getElementById('flute-option').style.display =
-        cleanName === 'Golem' ? 'block' : 'none';
+        selectedName === 'Golem' ? 'block' : 'none';
       if (usePreset.checked) {
         const chosen = enemies.find((e) => e.name === enemySelect.value);
         if (chosen) setMonsterStats(chosen);
@@ -242,7 +247,7 @@
         (document.getElementById('hero-death-necklace').checked ? 10 : 0);
       hero.attack = hero.strength + weaponAttack + bonusAttack;
       const monster = {
-        name: (enemySelect.value || 'Custom').replace(/\*/g, ''),
+        name: enemySelect.value || 'Custom',
         hp: Number(document.getElementById('mon-hp').value),
         attack: Number(document.getElementById('mon-attack').value),
         defense: Number(document.getElementById('mon-defense').value),


### PR DESCRIPTION
## Summary
- Populate hurt resist, dodge rate, and XP when loading preset monsters and when switching enemies
- Remove placeholder asterisks from enemy names and drop related trimming logic
- Set flute option visibility without relying on synthetic change events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898a3fbba10833285e9dde59c047c13