### PR TITLE
Add herb healing and fairy water attack items

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This project provides a lightweight JavaScript simulator inspired by the NES gam
 - After any ambush, the hero always acts before the monster each round.
 - Supports hero spells HURT, HURTMORE, HEAL, and HEALMORE with per-spell MP costs and enemy resistance to HURT-category magic.
 - Tracks MP spent by the hero across a battle.
+- Optional consumables: Herbs heal 23–30 HP (150 frames) while Fairy Water deals 9–16 damage (210 frames) and both ignore Stopspell.
 - Hero attack is derived from Strength, chosen weapon, and optional gear (Fighter's Ring +2 attack, Death Necklace +10 attack).
-- Hero picks the offensive action (attack, HURT, or HURTMORE) with the highest expected damage.
+- Hero picks the offensive action (attack, HURT, HURTMORE, or Fairy Water) with the highest expected damage.
 - Monsters may flee at the start of their turn if the hero's strength is at least twice the monster's attack (25% chance), ending the battle early with a 45-frame message and no experience.
 - Enemies have a configurable chance to dodge attacks (default 2/64).
 - Tracks total battle time in frames (60 frames = 1 second) using default action timings:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project provides a lightweight JavaScript simulator inspired by the NES gam
 - After any ambush, the hero always acts before the monster each round.
 - Supports hero spells HURT, HURTMORE, HEAL, and HEALMORE with per-spell MP costs and enemy resistance to HURT-category magic.
 - Tracks MP spent by the hero across a battle.
-- Optional consumables: Herbs heal 23–30 HP (150 frames) while Fairy Water deals 9–16 damage (210 frames) and both ignore Stopspell.
+- Optional consumables: Herbs heal 23–30 HP (150 frames) while Fairy Water deals 9–16 damage (210 frames, 0–1 against Metal Slimes) and both ignore Stopspell.
 - Hero attack is derived from Strength, chosen weapon, and optional gear (Fighter's Ring +2 attack, Death Necklace +10 attack).
 - Hero picks the offensive action (attack, HURT, HURTMORE, or Fairy Water) with the highest expected damage.
 - Monsters may flee at the start of their turn if the hero's strength is at least twice the monster's attack (25% chance), ending the battle early with a 45-frame message and no experience.

--- a/cli.js
+++ b/cli.js
@@ -9,6 +9,8 @@ const hero = {
   spells: ['HURT', 'HEAL', 'STOPSPELL'],
   armor: 'none',
   fairyFlute: true,
+  herbs: 0,
+  fairyWater: 0,
 };
 const weaponAttack = 20; // Broad Sword
 const fightersRing = false;
@@ -40,10 +42,20 @@ const settings = {
   enemyDodgeTime: 60,
 };
 
-const { winRate, averageXPPerMinute, averageMPSpent, averageTimeSeconds } =
-  simulateMany(hero, monster, settings, 100);
+const {
+  winRate,
+  averageXPPerMinute,
+  averageMPSpent,
+  averageTimeSeconds,
+  averageHerbsUsed,
+  averageFairyWatersUsed,
+} = simulateMany(hero, monster, settings, 100);
 
 console.log(`Win Rate: ${(winRate * 100).toFixed(2)}%`);
 console.log(`Average XP per minute: ${averageXPPerMinute.toFixed(2)}`);
 console.log(`Average MP spent per battle: ${averageMPSpent.toFixed(2)}`);
 console.log(`Average battle time (s): ${averageTimeSeconds.toFixed(2)}`);
+console.log(`Average herbs used per battle: ${averageHerbsUsed.toFixed(2)}`);
+console.log(
+  `Average fairy waters used per battle: ${averageFairyWatersUsed.toFixed(2)}`,
+);

--- a/index.html
+++ b/index.html
@@ -116,6 +116,8 @@
       <label>Defense <input type="number" id="hero-defense" value="40" /></label>
       <label>Agility <input type="number" id="hero-agility" value="30" /></label>
       <label>MP <input type="number" id="hero-mp" value="50" /></label>
+      <label>Herbs <input type="number" id="hero-herbs" value="0" min="0" max="6" /></label>
+      <label>Fairy Water <input type="number" id="hero-fairy-water" value="0" min="0" max="8" /></label>
       <label><input type="checkbox" id="hero-hurt" /> HURT</label>
       <label><input type="checkbox" id="hero-hurtmore" /> HURTMORE</label>
       <label><input type="checkbox" id="hero-heal" /> HEAL</label>
@@ -275,6 +277,10 @@
         defense: Number(document.getElementById('hero-defense').value),
         agility: Number(document.getElementById('hero-agility').value),
         mp: Number(document.getElementById('hero-mp').value),
+        herbs: Number(document.getElementById('hero-herbs').value),
+        fairyWater: Number(
+          document.getElementById('hero-fairy-water').value,
+        ),
         armor: document.getElementById('hero-armor').value,
         fairyFlute: document.getElementById('hero-flute').checked,
         spells: [
@@ -330,9 +336,14 @@
         `Win Rate: ${(summary.winRate * 100).toFixed(2)}%\n` +
         `Average XP per minute: ${summary.averageXPPerMinute.toFixed(2)}\n` +
         `Average MP spent per battle: ${summary.averageMPSpent.toFixed(2)}\n` +
+        `Average herbs used per battle: ${summary.averageHerbsUsed.toFixed(2)}\n` +
+        `Average fairy waters used per battle: ${summary.averageFairyWatersUsed.toFixed(2)}\n` +
         `Average battle time (s): ${summary.averageTimeSeconds.toFixed(2)}`;
       sampleEl.textContent =
-        `MP Spent: ${example.mpSpent}\n` + example.log.join('\n');
+        `MP Spent: ${example.mpSpent}\n` +
+        `Herbs Used: ${example.herbsUsed}\n` +
+        `Fairy Waters Used: ${example.fairyWatersUsed}\n` +
+        example.log.join('\n');
     });
   </script>
 </body>

--- a/simulator.js
+++ b/simulator.js
@@ -211,7 +211,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     }
 
     if (hero.fairyWater > 0) {
-      const avg = 12.5;
+      const avg = monster.name === 'Metal Slime' ? 0.5 : 12.5;
       if (avg > bestDamage) {
         bestDamage = avg;
         best = 'FAIRY_WATER';
@@ -289,7 +289,12 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
       return;
     }
     if (action === 'FAIRY_WATER') {
-      const dmg = 9 + Math.floor(Math.random() * 8);
+      const dmg =
+        monster.name === 'Metal Slime'
+          ? Math.random() < 0.5
+            ? 0
+            : 1
+          : 9 + Math.floor(Math.random() * 8);
       monster.hp -= dmg;
       hero.fairyWater--;
       fairyWatersUsed++;

--- a/tests.js
+++ b/tests.js
@@ -348,3 +348,84 @@ console.log('big breath mitigation distribution test passed');
   console.log('monster flee test passed');
 }
 
+// Hero uses an herb when no healing spells are available
+{
+  const seq = [0, 0, 0, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = { hp: 10, attack: 1, strength: 50, defense: 0, agility: 0, herbs: 1 };
+  const monster = { name: 'Slime', hp: 1, attack: 40, defense: 0, agility: 0, xp: 0 };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+  });
+  Math.random = orig;
+  assert(result.log.includes('Hero uses an herb and heals 0 HP.'));
+  assert.strictEqual(result.herbsUsed, 1);
+  console.log('herb usage test passed');
+}
+
+// Herb is not used when HEAL is available and affordable
+{
+  const seq = [0, 0, 0, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 10,
+    attack: 1,
+    strength: 50,
+    defense: 0,
+    agility: 0,
+    mp: 3,
+    spells: ['HEAL'],
+    herbs: 1,
+  };
+  const monster = { name: 'Slime', hp: 1, attack: 40, defense: 0, agility: 0, xp: 0 };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+  });
+  Math.random = orig;
+  assert(result.log.some((l) => l.startsWith('Hero casts HEAL')));
+  assert.strictEqual(result.herbsUsed, 0);
+  console.log('herb spell priority test passed');
+}
+
+// Hero uses Fairy Water for damage
+{
+  const seq = [0, 0, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = { hp: 10, attack: 0, strength: 50, defense: 0, agility: 0, fairyWater: 1 };
+  const monster = { name: 'Slime', hp: 9, attack: 0, defense: 0, agility: 0, xp: 0 };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+  });
+  Math.random = orig;
+  assert(result.log.includes('Hero uses Fairy Water for 9 damage.'));
+  assert.strictEqual(result.fairyWatersUsed, 1);
+  console.log('fairy water usage test passed');
+}
+

--- a/tests.js
+++ b/tests.js
@@ -429,3 +429,42 @@ console.log('big breath mitigation distribution test passed');
   console.log('fairy water usage test passed');
 }
 
+// Fairy Water does 0 or 1 damage to Metal Slimes
+{
+  const seq = [0, 0, 0, 0.5, 0, 0.75];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 10,
+    attack: 2,
+    strength: 50,
+    defense: 0,
+    agility: 0,
+    fairyWater: 2,
+  };
+  const monster = {
+    name: 'Metal Slime',
+    hp: 1,
+    attack: 0,
+    defense: 0,
+    agility: 0,
+    xp: 0,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+  });
+  Math.random = orig;
+  assert(result.log.includes('Hero uses Fairy Water for 0 damage.'));
+  assert(result.log.includes('Hero uses Fairy Water for 1 damage.'));
+  assert.strictEqual(result.fairyWatersUsed, 2);
+  console.log('metal slime fairy water test passed');
+}
+


### PR DESCRIPTION
## Summary
- Support herb items that heal 23–30 HP, consume inventory, and take 150 frames
- Add Fairy Water attack item for 9–16 damage and 210 frame cost
- Track and display herb and Fairy Water usage in results, CLI, and browser UI

## Testing
- `npm test`
- `npm run cli`


------
https://chatgpt.com/codex/tasks/task_e_6898c662690883328b067f51a4a09e9e