### PR TITLE
Add hero critical hit mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@ This project provides a lightweight JavaScript simulator inspired by the NES gam
 - Optional consumables: Herbs heal 23–30 HP (150 frames) while Fairy Water deals 9–16 damage (210 frames, 0–1 against Metal Slimes) and both ignore Stopspell.
 - Hero attack is derived from Strength, chosen weapon, and optional gear (Fighter's Ring +2 attack, Death Necklace +10 attack).
 - Hero picks the offensive action (attack, HURT, HURTMORE, or Fairy Water) with the highest expected damage.
+- Physical attacks have a 1/32 chance to become critical hits dealing 50–100% of attack power and adding 40 frames.
 - Monsters may flee at the start of their turn if the hero's strength is at least twice the monster's attack (25% chance), ending the battle early with a 45-frame message and no experience.
 - Enemies have a configurable chance to dodge attacks (default 2/64).
 - Tracks total battle time in frames (60 frames = 1 second) using default action timings:
   - Hero attack: 120 frames
   - Hero spell: 180 frames
+  - Critical hit bonus: 40 frames
+  - Herb use: 150 frames
+  - Fairy Water use: 210 frames
   - Enemy attack: 150 frames
   - Enemy spell: 170 frames
   - Enemy breath: 160 frames
@@ -30,7 +34,7 @@ This project provides a lightweight JavaScript simulator inspired by the NES gam
 
 ## Usage
 ### Browser
-Open `index.html` in any modern browser. Adjust the hero, monster, and simulation settings and click **Simulate** to see win rate, XP per minute, average battle time, and MP usage along with a sample battle log.
+Open `index.html` in any modern browser. Adjust the hero, monster, and simulation settings and click **Simulate** to see hero win rate, monster win rate, monster flee rate, XP per minute, average battle time, and MP usage along with a sample battle log.
 
 ### Command line
 Run the test suite:

--- a/cli.js
+++ b/cli.js
@@ -44,6 +44,8 @@ const settings = {
 
 const {
   winRate,
+  monsterWinRate,
+  monsterFleeRate,
   averageXPPerMinute,
   averageMPSpent,
   averageTimeSeconds,
@@ -51,7 +53,9 @@ const {
   averageFairyWatersUsed,
 } = simulateMany(hero, monster, settings, 100);
 
-console.log(`Win Rate: ${(winRate * 100).toFixed(2)}%`);
+console.log(`Hero Win Rate: ${(winRate * 100).toFixed(2)}%`);
+console.log(`Monster Win Rate: ${(monsterWinRate * 100).toFixed(2)}%`);
+console.log(`Monster Flee Rate: ${(monsterFleeRate * 100).toFixed(2)}%`);
 console.log(`Average XP per minute: ${averageXPPerMinute.toFixed(2)}`);
 console.log(`Average MP spent per battle: ${averageMPSpent.toFixed(2)}`);
 console.log(`Average battle time (s): ${averageTimeSeconds.toFixed(2)}`);

--- a/index.html
+++ b/index.html
@@ -185,6 +185,9 @@
         <summary>Timing Settings (optional)</summary>
         <label>Hero Attack Time (frames) <input type="number" id="hero-attack-time" value="120" /></label>
         <label>Hero Spell Time (frames) <input type="number" id="hero-spell-time" value="180" /></label>
+        <label>Critical Hit Time (frames) <input type="number" id="hero-critical-time" value="40" /></label>
+        <label>Herb Use Time (frames) <input type="number" id="herb-time" value="150" /></label>
+        <label>Fairy Water Use Time (frames) <input type="number" id="fairy-water-time" value="210" /></label>
         <label>Enemy Attack Time (frames) <input type="number" id="enemy-attack-time" value="150" /></label>
         <label>Enemy Spell Time (frames) <input type="number" id="enemy-spell-time" value="170" /></label>
         <label>Enemy Breath Time (frames) <input type="number" id="enemy-breath-time" value="160" /></label>
@@ -314,6 +317,9 @@
       const settings = {
         heroAttackTime: Number(document.getElementById('hero-attack-time').value),
         heroSpellTime: Number(document.getElementById('hero-spell-time').value),
+        heroCriticalTime: Number(document.getElementById('hero-critical-time').value),
+        herbTime: Number(document.getElementById('herb-time').value),
+        fairyWaterTime: Number(document.getElementById('fairy-water-time').value),
         enemyAttackTime: Number(document.getElementById('enemy-attack-time').value),
         enemySpellTime: Number(document.getElementById('enemy-spell-time').value),
         enemyBreathTime: Number(document.getElementById('enemy-breath-time').value),
@@ -333,7 +339,9 @@
       const example = simulateBattle(hero, exampleMonster, settings);
 
       metricsEl.textContent =
-        `Win Rate: ${(summary.winRate * 100).toFixed(2)}%\n` +
+        `Hero Win Rate: ${(summary.winRate * 100).toFixed(2)}%\n` +
+        `Monster Win Rate: ${(summary.monsterWinRate * 100).toFixed(2)}%\n` +
+        `Monster Flee Rate: ${(summary.monsterFleeRate * 100).toFixed(2)}%\n` +
         `Average XP per minute: ${summary.averageXPPerMinute.toFixed(2)}\n` +
         `Average MP spent per battle: ${summary.averageMPSpent.toFixed(2)}\n` +
         `Average herbs used per battle: ${summary.averageHerbsUsed.toFixed(2)}\n` +


### PR DESCRIPTION
## Summary
- Give hero physical attacks a 1/32 critical hit chance that deals 50–100% of attack power and adds 40 frames
- Expose critical hit bonus, herb use, and Fairy Water use timings as configurable simulation settings and update the UI
- Document critical hit and action timing options in the README
- Extend tests to cover the new mechanic, configurable timings, and battle outcome rates
- Report monster win and flee rates alongside hero wins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898cbd43cb08332969ef931846486e1