### PR TITLE
Handle weak hero attack damage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project provides a lightweight JavaScript simulator inspired by the NES gam
 - Hero attack is derived from Strength, chosen weapon, and optional gear (Fighter's Ring +2 attack, Death Necklace +10 attack).
 - Hero picks the offensive action (attack, HURT, HURTMORE, or Fairy Water) with the highest expected damage.
 - Physical attacks have a 1/32 chance to become critical hits dealing 50–100% of attack power and adding 40 frames.
+- When the hero's attack is less than the monster's defense + 2, normal attack damage is replaced with a 50% chance of dealing 0 or 1 damage.
 - Monsters may flee at the start of their turn if the hero's strength is at least twice the monster's attack (25% chance), ending the battle early with a 45-frame message and no experience.
 - Enemies have a configurable chance to dodge attacks (default 2/64).
 - Tracks total battle time in frames (60 frames = 1 second) using default action timings:

--- a/simulator.js
+++ b/simulator.js
@@ -2,7 +2,15 @@ export function baseMaxDamage(attack, defense) {
   return Math.max(0, (attack - defense) / 2);
 }
 
-export function computeDamage(attack, defense, rng = Math.random) {
+export function computeDamage(
+  attack,
+  defense,
+  rng = Math.random,
+  heroAttack = false,
+) {
+  if (heroAttack && attack < defense + 2) {
+    return rng() < 0.5 ? 0 : 1;
+  }
   const maxDamage = baseMaxDamage(attack, defense);
   const minQ = Math.floor((maxDamage / 2) * 4);
   const maxQ = Math.floor(maxDamage * 4);
@@ -11,7 +19,8 @@ export function computeDamage(attack, defense, rng = Math.random) {
   return Math.max(0, dmg);
 }
 
-function averagePhysicalDamage(attack, defense) {
+function averagePhysicalDamage(attack, defense, heroAttack = false) {
+  if (heroAttack && attack < defense + 2) return 0.5;
   const maxDamage = baseMaxDamage(attack, defense);
   const minQ = Math.floor((maxDamage / 2) * 4);
   const maxQ = Math.floor(maxDamage * 4);
@@ -194,7 +203,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     }
 
     let best = 'attack';
-    let bestDamage = averagePhysicalDamage(hero.attack, monster.defense);
+    let bestDamage = averagePhysicalDamage(hero.attack, monster.defense, true);
 
     if (!hero.stopspelled && hero.spells) {
       if (hero.spells.includes('HURTMORE') && hero.mp >= HERO_SPELL_COST.HURTMORE) {
@@ -319,7 +328,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
         timeFrames += heroAttackTime + heroCriticalTime;
         log.push(`Hero performs a critical hit for ${dmg} damage.`);
       } else {
-        const dmg = computeDamage(hero.attack, monster.defense);
+        const dmg = computeDamage(hero.attack, monster.defense, Math.random, true);
         monster.hp -= dmg;
         timeFrames += heroAttackTime;
         log.push(`Hero attacks for ${dmg} damage.`);

--- a/tests.js
+++ b/tests.js
@@ -27,6 +27,17 @@ assert(Math.abs(avg - 10.875) < 0.01);
 
 console.log('computeDamage average test passed');
 
+// When hero attack is less than monster defense + 2, damage is 0 or 1
+{
+  const lowAttack = 5;
+  const highDefense = 10;
+  const dmgLow = computeDamage(lowAttack, highDefense, () => 0.49, true);
+  const dmgHigh = computeDamage(lowAttack, highDefense, () => 0.5, true);
+  assert.strictEqual(dmgLow, 0);
+  assert.strictEqual(dmgHigh, 1);
+  console.log('hero weak attack damage test passed');
+}
+
 const counts = {};
 for (let i = 0; i < 8; i++) {
   const rng = () => (i + 0.5) / 8;


### PR DESCRIPTION
## Summary
- Add special case for hero physical attacks when Attack < Defense + 2, giving a 50% chance of 0 or 1 damage
- Document weak attack rule in README
- Cover weak attack behavior with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898d308712883328fc61cc728462f7e