### PR TITLE
Stop battle after monster flees on ambush

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -154,11 +154,12 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
   if (heroRoll < enemyRoll) {
     log.push('Monster ambushes!');
     runMonsterTurn();
-    if (hero.hp <= 0) {
-      timeFrames += postBattleTime;
+    if (hero.hp <= 0 || monster.fled) {
+      timeFrames += monster.fled ? 45 : postBattleTime;
+      const winner = monster.fled ? 'fled' : 'monster';
       const timeSeconds = timeFrames / 60;
       return {
-        winner: 'monster',
+        winner,
         rounds,
         timeFrames,
         timeSeconds,
@@ -447,10 +448,10 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     log.push(`Monster attacks for ${dmg} damage.`);
   }
 
-  while (hero.hp > 0 && monster.hp > 0) {
+  while (hero.hp > 0 && monster.hp > 0 && !monster.fled) {
     rounds++;
     runHeroTurn();
-    if (hero.hp <= 0 || monster.hp <= 0) break;
+    if (hero.hp <= 0 || monster.hp <= 0 || monster.fled) break;
     runMonsterTurn();
     if (monster.fled) break;
   }

--- a/tests.js
+++ b/tests.js
@@ -240,6 +240,39 @@ console.log('big breath mitigation distribution test passed');
   assert(result.log.includes('Hero is asleep.'));
   console.log('ambush support ability test passed');
 }
+
+// Monster fleeing during an ambush ends the battle before hero acts
+{
+  const seq = [0, 0.99, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = { hp: 10, attack: 0, strength: 20, defense: 0, agility: 10 };
+  const monster = {
+    name: 'Runner',
+    hp: 10,
+    attack: 10,
+    defense: 0,
+    agility: 10,
+    xp: 5,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+  });
+  Math.random = orig;
+  assert.deepStrictEqual(result.log, ['Monster ambushes!', 'Monster runs away!']);
+  assert.strictEqual(result.winner, 'fled');
+  assert.strictEqual(result.rounds, 0);
+  assert.strictEqual(result.timeFrames, 45);
+  console.log('ambush flee logic test passed');
+}
 // simulateMany returns average battle time in seconds
 {
   const seq = [0.5, 0, 0, 0.5, 0.5, 0.5];


### PR DESCRIPTION
## Summary
- handle monster fleeing on ambush by ending battle immediately
- prevent extra turns after a monster flees
- test ambush flee scenario

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f15deda88332890a5be96395f297