### PR TITLE
Stop hero action after ambushed monster flees

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -154,21 +154,21 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
   if (heroRoll < enemyRoll) {
     log.push('Monster ambushes!');
     runMonsterTurn();
-    if (hero.hp <= 0 || monster.fled) {
-      timeFrames += monster.fled ? 45 : postBattleTime;
-      const winner = monster.fled ? 'fled' : 'monster';
-      const timeSeconds = timeFrames / 60;
-      return {
-        winner,
-        rounds,
-        timeFrames,
-        timeSeconds,
-        xpGained: 0,
-        xpPerMinute: 0,
-        mpSpent,
-        log,
-      };
-    }
+  }
+  if (hero.hp <= 0 || monster.fled) {
+    timeFrames += monster.fled ? 45 : postBattleTime;
+    const winner = monster.fled ? 'fled' : 'monster';
+    const timeSeconds = timeFrames / 60;
+    return {
+      winner,
+      rounds,
+      timeFrames,
+      timeSeconds,
+      xpGained: 0,
+      xpPerMinute: 0,
+      mpSpent,
+      log,
+    };
   }
 
   function determineHeroAction() {

--- a/tests.js
+++ b/tests.js
@@ -273,6 +273,47 @@ console.log('big breath mitigation distribution test passed');
   assert.strictEqual(result.timeFrames, 45);
   console.log('ambush flee logic test passed');
 }
+
+// Metal Slime ambush flee ends battle without hero action
+{
+  const seq = [0, 0.99, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 100,
+    attack: 50,
+    strength: 50,
+    defense: 40,
+    agility: 30,
+    mp: 0,
+  };
+  const monster = {
+    name: 'Metal Slime',
+    hp: 3,
+    attack: 10,
+    defense: 127,
+    agility: 255,
+    xp: 255,
+    hurtResist: 15,
+    dodge: 1,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+  });
+  Math.random = orig;
+  assert.deepStrictEqual(result.log, ['Monster ambushes!', 'Monster runs away!']);
+  assert.strictEqual(result.winner, 'fled');
+  assert.strictEqual(result.rounds, 0);
+  console.log('metal slime ambush flee test passed');
+}
 // simulateMany returns average battle time in seconds
 {
   const seq = [0.5, 0, 0, 0.5, 0.5, 0.5];


### PR DESCRIPTION
## Summary
- Ensure ambush sequences exit immediately if the monster flees before the hero acts
- Add regression test for Metal Slime ambush run-away scenario

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f37b32ac8332b7c972cfa52f1e19