### PR TITLE
Add repeated battle simulation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ This project provides a lightweight JavaScript simulator inspired by the NES gam
 - Heroes can cast STOPSPELL to silence enemy spellcasting based on the monster's Stopspell resistance (0–15 out of 16). Stopspelled monsters still attempt to cast but their spells fail and cost 60 fewer frames than normal.
 - When fighting the Golem, the hero can optionally carry the Fairy Flute. Playing it (480 frames) puts the Golem to sleep for one guaranteed turn and gives it a 33% wake chance on later turns.
 - Computes experience gained, average battle duration, and XP per minute.
+- Repeated fight mode chains battles until the hero dies, allowing healing between fights and reporting total XP per life, XP per minute, enemies defeated, and MP used per fight.
 - Browser interface for quick experimentation and a CLI example.
 - Web UI includes preset enemy selector with stats and an option to override them; enemy HP is randomized each fight between 75% and 100% of its listed maximum. Timing values default to the NES speeds but can be tweaked in a hidden advanced section.
 
 ## Usage
 ### Browser
-Open `index.html` in any modern browser. Adjust the hero, monster, and simulation settings and click **Simulate** to see hero win rate, monster win rate, monster flee rate, XP per minute, average battle time, and MP usage along with a sample battle log.
+Open `index.html` in any modern browser. Adjust the hero, monster, and simulation settings and click **Simulate**. Choose between single battles or repeated fights to see either win rates and XP per minute or total XP per life, kill counts, and MP usage, along with a sample battle log.
 
 ### Command line
 Run the test suite:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This project provides a lightweight JavaScript simulator inspired by the NES gam
 - Heroes can cast STOPSPELL to silence enemy spellcasting based on the monster's Stopspell resistance (0–15 out of 16). Stopspelled monsters still attempt to cast but their spells fail and cost 60 fewer frames than normal.
 - When fighting the Golem, the hero can optionally carry the Fairy Flute. Playing it (480 frames) puts the Golem to sleep for one guaranteed turn and gives it a 33% wake chance on later turns.
 - Computes experience gained, average battle duration, and XP per minute.
-- Repeated fight mode chains battles until the hero dies, allowing healing between fights and reporting total XP per life, XP per minute, enemies defeated, and MP used per fight.
+- Repeated fight mode chains battles until the hero dies, allowing healing between fights and reporting total XP per life, XP per minute, enemies defeated, and MP used per fight, with a configurable 30-frame pause between battles.
 - Browser interface for quick experimentation and a CLI example.
 - Web UI includes preset enemy selector with stats and an option to override them; enemy HP is randomized each fight between 75% and 100% of its listed maximum. Timing values default to the NES speeds but can be tweaked in a hidden advanced section.
 

--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,4 @@
-import { simulateMany } from './simulator.js';
+import { simulateMany, simulateRepeated } from './simulator.js';
 
 const hero = {
   hp: 100,
@@ -63,3 +63,9 @@ console.log(`Average herbs used per battle: ${averageHerbsUsed.toFixed(2)}`);
 console.log(
   `Average fairy waters used per battle: ${averageFairyWatersUsed.toFixed(2)}`,
 );
+
+const repeated = simulateRepeated(hero, monster, settings, 100);
+console.log(`Average XP per life: ${repeated.averageXPPerLife.toFixed(2)}`);
+console.log(`Average XP per minute: ${repeated.averageXPPerMinute.toFixed(2)}`);
+console.log(`Average enemies killed per life: ${repeated.averageKills.toFixed(2)}`);
+console.log(`Average MP spent per fight: ${repeated.averageMPPerFight.toFixed(2)}`);

--- a/cli.js
+++ b/cli.js
@@ -36,10 +36,12 @@ const settings = {
   postBattleTime: 200,
   heroAttackTime: 120,
   heroSpellTime: 180,
+  herbTime: 150,
   enemyAttackTime: 150,
   enemySpellTime: 170,
   enemyBreathTime: 160,
   enemyDodgeTime: 60,
+  framesBetweenFights: 30,
 };
 
 const {

--- a/index.html
+++ b/index.html
@@ -195,6 +195,12 @@
         <label>Pre-Battle Time (frames) <input type="number" id="pre-battle-time" value="140" /></label>
         <label>Post-Battle Time (frames) <input type="number" id="post-battle-time" value="200" /></label>
       </details>
+      <label>Mode
+        <select id="sim-mode">
+          <option value="single">Single Battle</option>
+          <option value="repeated">Repeated Fights</option>
+        </select>
+      </label>
       <label>Iterations <input type="number" id="iterations" value="1000" /></label>
     </fieldset>
     <button type="submit">Simulate</button>
@@ -213,7 +219,7 @@
   </div>
 
   <script type="module">
-    import { simulateMany, simulateBattle } from './simulator.js';
+    import { simulateMany, simulateBattle, simulateRepeated } from './simulator.js';
 
     const form = document.getElementById('sim-form');
     const metricsEl = document.getElementById('metrics');
@@ -328,8 +334,12 @@
         postBattleTime: Number(document.getElementById('post-battle-time').value),
       };
       const iterations = Number(document.getElementById('iterations').value);
+      const mode = document.getElementById('sim-mode').value;
 
-      const summary = simulateMany(hero, monster, settings, iterations);
+      const summary =
+        mode === 'repeated'
+          ? simulateRepeated(hero, monster, settings, iterations)
+          : simulateMany(hero, monster, settings, iterations);
       const hpMax = monster.hp;
       const hpMin = Math.ceil(hpMax * 0.75);
       const exampleMonster = {
@@ -339,14 +349,19 @@
       const example = simulateBattle(hero, exampleMonster, settings);
 
       metricsEl.textContent =
-        `Hero Win Rate: ${(summary.winRate * 100).toFixed(2)}%\n` +
-        `Monster Win Rate: ${(summary.monsterWinRate * 100).toFixed(2)}%\n` +
-        `Monster Flee Rate: ${(summary.monsterFleeRate * 100).toFixed(2)}%\n` +
-        `Average XP per minute: ${summary.averageXPPerMinute.toFixed(2)}\n` +
-        `Average MP spent per battle: ${summary.averageMPSpent.toFixed(2)}\n` +
-        `Average herbs used per battle: ${summary.averageHerbsUsed.toFixed(2)}\n` +
-        `Average fairy waters used per battle: ${summary.averageFairyWatersUsed.toFixed(2)}\n` +
-        `Average battle time (s): ${summary.averageTimeSeconds.toFixed(2)}`;
+        mode === 'repeated'
+          ? `Average XP per life: ${summary.averageXPPerLife.toFixed(2)}\n` +
+            `Average XP per minute: ${summary.averageXPPerMinute.toFixed(2)}\n` +
+            `Average enemies defeated per life: ${summary.averageKills.toFixed(2)}\n` +
+            `Average MP spent per fight: ${summary.averageMPPerFight.toFixed(2)}`
+          : `Hero Win Rate: ${(summary.winRate * 100).toFixed(2)}%\n` +
+            `Monster Win Rate: ${(summary.monsterWinRate * 100).toFixed(2)}%\n` +
+            `Monster Flee Rate: ${(summary.monsterFleeRate * 100).toFixed(2)}%\n` +
+            `Average XP per minute: ${summary.averageXPPerMinute.toFixed(2)}\n` +
+            `Average MP spent per battle: ${summary.averageMPSpent.toFixed(2)}\n` +
+            `Average herbs used per battle: ${summary.averageHerbsUsed.toFixed(2)}\n` +
+            `Average fairy waters used per battle: ${summary.averageFairyWatersUsed.toFixed(2)}\n` +
+            `Average battle time (s): ${summary.averageTimeSeconds.toFixed(2)}`;
       sampleEl.textContent =
         `MP Spent: ${example.mpSpent}\n` +
         `Herbs Used: ${example.herbsUsed}\n` +

--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
         <label>Enemy Dodge Time (frames) <input type="number" id="enemy-dodge-time" value="60" /></label>
         <label>Pre-Battle Time (frames) <input type="number" id="pre-battle-time" value="140" /></label>
         <label>Post-Battle Time (frames) <input type="number" id="post-battle-time" value="200" /></label>
+        <label>Between Fights Time (frames) <input type="number" id="frames-between-fights" value="30" /></label>
       </details>
       <label>Mode
         <select id="sim-mode">
@@ -332,6 +333,9 @@
         enemyDodgeTime: Number(document.getElementById('enemy-dodge-time').value),
         preBattleTime: Number(document.getElementById('pre-battle-time').value),
         postBattleTime: Number(document.getElementById('post-battle-time').value),
+        framesBetweenFights: Number(
+          document.getElementById('frames-between-fights').value,
+        ),
       };
       const iterations = Number(document.getElementById('iterations').value);
       const mode = document.getElementById('sim-mode').value;

--- a/simulator.js
+++ b/simulator.js
@@ -527,8 +527,9 @@ export function simulateMany(hero, monster, settings = {}, iterations = 1) {
 }
 
 function healBetweenFights(hero, monster, settings) {
-  const { heroSpellTime = 180, herbTime = 150 } = settings;
-  let frames = 30;
+  const heroSpellTime = settings.heroSpellTime;
+  const herbTime = settings.herbTime;
+  let framesBetweenFights = settings.framesBetweenFights;
   let mp = 0;
   const maxDmg = maxMonsterDamage(hero, monster);
   while (hero.hp < hero.maxHp && hero.hp <= 2 * maxDmg) {
@@ -543,7 +544,7 @@ function healBetweenFights(hero, monster, settings) {
       hero.hp += actual;
       hero.mp -= HERO_SPELL_COST.HEAL;
       mp += HERO_SPELL_COST.HEAL;
-      frames += heroSpellTime;
+      framesBetweenFights += heroSpellTime;
       continue;
     }
     if (
@@ -554,7 +555,7 @@ function healBetweenFights(hero, monster, settings) {
       const actual = Math.min(heal, hero.maxHp - hero.hp);
       hero.hp += actual;
       hero.herbs--;
-      frames += herbTime;
+      framesBetweenFights += herbTime;
       continue;
     }
     if (
@@ -566,12 +567,12 @@ function healBetweenFights(hero, monster, settings) {
       hero.hp += actual;
       hero.mp -= HERO_SPELL_COST.HEALMORE;
       mp += HERO_SPELL_COST.HEALMORE;
-      frames += heroSpellTime;
+      framesBetweenFights += heroSpellTime;
       continue;
     }
     break;
   }
-  return { frames, mpSpent: mp };
+  return { frames: framesBetweenFights, mpSpent: mp };
 }
 
 export function simulateRepeated(heroStats, monsterStats, settings = {}, iterations = 1) {


### PR DESCRIPTION
## Summary
- support calculating a monster's max possible damage
- introduce repeated battle simulation with healing between fights
- expose new mode in CLI and browser UI and document its use

## Testing
- `npm test`
- `node cli.js`


------
https://chatgpt.com/codex/tasks/task_e_689907f4a9b08332a4f6a5398cbf82cb