### PR TITLE
Expand repeated fight battle logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,13 +344,18 @@
         mode === 'repeated'
           ? simulateRepeated(hero, monster, settings, iterations)
           : simulateMany(hero, monster, settings, iterations);
-      const hpMax = monster.hp;
-      const hpMin = Math.ceil(hpMax * 0.75);
-      const exampleMonster = {
-        ...monster,
-        hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
-      };
-      const example = simulateBattle(hero, exampleMonster, settings);
+      let example;
+      if (mode === 'repeated') {
+        example = summary;
+      } else {
+        const hpMax = monster.hp;
+        const hpMin = Math.ceil(hpMax * 0.75);
+        const exampleMonster = {
+          ...monster,
+          hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
+        };
+        example = simulateBattle(hero, exampleMonster, settings);
+      }
 
       metricsEl.textContent =
         mode === 'repeated'


### PR DESCRIPTION
## Summary
- log monster and hero defeats at the end of battles
- include healing actions and start-of-fight markers in repeated fight logs
- surface full life log and resource use in the UI for repeated mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899163602ac8332901fa69c71e36c39