### PR TITLE
Preserve hero max HP across repeated battles

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,14 @@
 import { simulateMany, simulateRepeated } from './simulator.js';
 
+function formatTime(seconds) {
+  const minutes = Math.floor(seconds / 60);
+  const secs = (seconds % 60).toFixed(2);
+  return `${minutes}m ${secs}s`;
+}
+
 const hero = {
   hp: 100,
+  maxHp: 100,
   strength: 50,
   defense: 40,
   agility: 30,
@@ -71,3 +78,4 @@ console.log(`Average XP per life: ${repeated.averageXPPerLife.toFixed(2)}`);
 console.log(`Average XP per minute: ${repeated.averageXPPerMinute.toFixed(2)}`);
 console.log(`Average enemies killed per life: ${repeated.averageKills.toFixed(2)}`);
 console.log(`Average MP spent per fight: ${repeated.averageMPPerFight.toFixed(2)}`);
+console.log(`Average time per life: ${formatTime(repeated.averageTimeSeconds)}`);

--- a/index.html
+++ b/index.html
@@ -231,6 +231,12 @@
 
     let enemies = [];
 
+    function formatTime(seconds) {
+      const minutes = Math.floor(seconds / 60);
+      const secs = (seconds % 60).toFixed(2);
+      return `${minutes}m ${secs}s`;
+    }
+
     function setMonsterStats(chosen) {
       document.getElementById('mon-hp').value = chosen.hp;
       document.getElementById('mon-attack').value = chosen.attack;
@@ -283,6 +289,7 @@
       e.preventDefault();
       const hero = {
         hp: Number(document.getElementById('hero-hp').value),
+        maxHp: Number(document.getElementById('hero-hp').value),
         strength: Number(document.getElementById('hero-strength').value),
         defense: Number(document.getElementById('hero-defense').value),
         agility: Number(document.getElementById('hero-agility').value),
@@ -361,6 +368,7 @@
         mode === 'repeated'
           ? `Average XP per life: ${summary.averageXPPerLife.toFixed(2)}\n` +
             `Average XP per minute: ${summary.averageXPPerMinute.toFixed(2)}\n` +
+            `Average time per life: ${formatTime(summary.averageTimeSeconds)}\n` +
             `Average enemies defeated per life: ${summary.averageKills.toFixed(2)}\n` +
             `Average MP spent per fight: ${summary.averageMPPerFight.toFixed(2)}`
           : `Hero Win Rate: ${(summary.winRate * 100).toFixed(2)}%\n` +
@@ -372,6 +380,7 @@
             `Average fairy waters used per battle: ${summary.averageFairyWatersUsed.toFixed(2)}\n` +
             `Average battle time (s): ${summary.averageTimeSeconds.toFixed(2)}`;
       sampleEl.textContent =
+        `Total Time: ${formatTime(example.timeFrames / 60)}\n` +
         `MP Spent: ${example.mpSpent}\n` +
         `Herbs Used: ${example.herbsUsed}\n` +
         `Fairy Waters Used: ${example.fairyWatersUsed}\n` +

--- a/simulator.js
+++ b/simulator.js
@@ -136,7 +136,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     ...heroStats,
     armor,
     mp: heroStats.mp ?? 0,
-    maxHp: heroStats.hp,
+    maxHp: heroStats.maxHp,
     stopspelled: false,
     asleep: false,
     sleepTurns: 0,
@@ -599,11 +599,12 @@ export function simulateRepeated(heroStats, monsterStats, settings = {}, iterati
   let sampleMpSpent = 0;
   let sampleHerbsUsed = 0;
   let sampleFairyWatersUsed = 0;
+  let sampleFrames = 0;
   for (let i = 0; i < iterations; i++) {
     let hero = {
       ...heroStats,
       mp: heroStats.mp ?? 0,
-      maxHp: heroStats.hp,
+      maxHp: heroStats.maxHp,
       herbs: heroStats.herbs || 0,
       fairyWater: heroStats.fairyWater || 0,
     };
@@ -666,17 +667,21 @@ export function simulateRepeated(heroStats, monsterStats, settings = {}, iterati
       sampleMpSpent = mpSpent;
       sampleHerbsUsed = herbsUsed;
       sampleFairyWatersUsed = fairyWatersUsed;
+      sampleFrames = frames;
     }
   }
   const averageXPPerMinute = totalFrames === 0 ? 0 : (totalXP * 3600) / totalFrames;
+  const averageTimeSeconds = totalFrames / iterations / 60;
   return {
     averageXPPerLife: totalXP / iterations,
     averageXPPerMinute,
+    averageTimeSeconds,
     averageKills: totalKills / iterations,
     averageMPPerFight: totalFights === 0 ? 0 : totalMP / totalFights,
     mpSpent: sampleMpSpent,
     herbsUsed: sampleHerbsUsed,
     fairyWatersUsed: sampleFairyWatersUsed,
+    timeFrames: sampleFrames,
     log: sampleLog,
   };
 }

--- a/tests.js
+++ b/tests.js
@@ -77,6 +77,7 @@ console.log('big breath mitigation distribution test passed');
   Math.random = () => seq[i++] ?? 0;
   const hero = {
     hp: 1,
+    maxHp: 1,
     attack: 0,
     strength: 50,
     defense: 0,
@@ -102,6 +103,7 @@ console.log('big breath mitigation distribution test passed');
   Math.random = () => seq[i++] ?? 0;
   const hero = {
     hp: 10,
+    maxHp: 10,
     attack: 100,
     strength: 100,
     defense: 0,
@@ -145,6 +147,7 @@ console.log('big breath mitigation distribution test passed');
   Math.random = () => seq[i++] ?? 0;
   const hero = {
     hp: 10,
+    maxHp: 10,
     attack: 100,
     strength: 100,
     defense: 0,
@@ -181,7 +184,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 64, strength: 64, defense: 0, agility: 0 };
+  const hero = { hp: 10, maxHp: 10, attack: 64, strength: 64, defense: 0, agility: 0 };
   const monster = {
     name: 'Dummy',
     hp: 30,
@@ -214,7 +217,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 0, strength: 50, defense: 0, agility: 10 };
+  const hero = { hp: 10, maxHp: 10, attack: 0, strength: 50, defense: 0, agility: 10 };
   const monster = {
     name: 'Mage',
     hp: 10,
@@ -248,7 +251,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 0, strength: 20, defense: 0, agility: 10 };
+  const hero = { hp: 10, maxHp: 10, attack: 0, strength: 20, defense: 0, agility: 10 };
   const monster = {
     name: 'Runner',
     hp: 10,
@@ -283,6 +286,7 @@ console.log('big breath mitigation distribution test passed');
   Math.random = () => seq[i++] ?? 0;
   const hero = {
     hp: 100,
+    maxHp: 100,
     attack: 50,
     strength: 50,
     defense: 40,
@@ -321,7 +325,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 100, strength: 100, defense: 0, agility: 10 };
+  const hero = { hp: 10, maxHp: 10, attack: 100, strength: 100, defense: 0, agility: 10 };
   const monster = { name: 'Slime', hp: 1, attack: 0, defense: 0, agility: 0, xp: 0 };
   const summary = simulateMany(
     hero,
@@ -396,7 +400,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 0, strength: 50, defense: 0, agility: 10 };
+  const hero = { hp: 10, maxHp: 10, attack: 0, strength: 50, defense: 0, agility: 10 };
   const monster = {
     name: 'Healer',
     hp: 25,
@@ -428,7 +432,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 1, attack: 0, strength: 50, defense: 0, agility: 10 };
+  const hero = { hp: 1, maxHp: 1, attack: 0, strength: 50, defense: 0, agility: 10 };
   const monster = {
     name: 'Healer',
     hp: 20,
@@ -463,6 +467,7 @@ console.log('big breath mitigation distribution test passed');
   Math.random = () => seq[i++] ?? 0;
   const hero = {
     hp: 100,
+    maxHp: 100,
     attack: 0,
     strength: 200,
     defense: 0,
@@ -500,7 +505,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 0, strength: 20, defense: 0, agility: 10 };
+  const hero = { hp: 10, maxHp: 10, attack: 0, strength: 20, defense: 0, agility: 10 };
   const monster = { name: 'Runner', hp: 10, attack: 10, defense: 0, agility: 10, xp: 5 };
   const result = simulateBattle(hero, monster, {
     preBattleTime: 0,
@@ -525,7 +530,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 1, strength: 50, defense: 0, agility: 0, herbs: 1 };
+  const hero = { hp: 10, maxHp: 10, attack: 1, strength: 50, defense: 0, agility: 0, herbs: 1 };
   const monster = { name: 'Slime', hp: 1, attack: 40, defense: 0, agility: 0, xp: 0 };
   const result = simulateBattle(hero, monster, {
     preBattleTime: 0,
@@ -549,7 +554,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 1, strength: 50, defense: 0, agility: 0, herbs: 1 };
+  const hero = { hp: 10, maxHp: 10, attack: 1, strength: 50, defense: 0, agility: 0, herbs: 1 };
   const monster = { name: 'Slime', hp: 1, attack: 40, defense: 0, agility: 0, xp: 0 };
   const result = simulateBattle(hero, monster, {
     preBattleTime: 0,
@@ -575,6 +580,7 @@ console.log('big breath mitigation distribution test passed');
   Math.random = () => seq[i++] ?? 0;
   const hero = {
     hp: 10,
+    maxHp: 10,
     attack: 1,
     strength: 50,
     defense: 0,
@@ -606,7 +612,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 0, strength: 50, defense: 0, agility: 0, fairyWater: 1 };
+  const hero = { hp: 10, maxHp: 10, attack: 0, strength: 50, defense: 0, agility: 0, fairyWater: 1 };
   const monster = { name: 'Slime', hp: 9, attack: 0, defense: 0, agility: 0, xp: 0 };
   const result = simulateBattle(hero, monster, {
     preBattleTime: 0,
@@ -630,7 +636,7 @@ console.log('big breath mitigation distribution test passed');
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
-  const hero = { hp: 10, attack: 0, strength: 50, defense: 0, agility: 0, fairyWater: 1 };
+  const hero = { hp: 10, maxHp: 10, attack: 0, strength: 50, defense: 0, agility: 0, fairyWater: 1 };
   const monster = { name: 'Slime', hp: 9, attack: 0, defense: 0, agility: 0, xp: 0 };
   const result = simulateBattle(hero, monster, {
     preBattleTime: 0,
@@ -656,6 +662,7 @@ console.log('big breath mitigation distribution test passed');
   Math.random = () => seq[i++] ?? 0;
   const hero = {
     hp: 10,
+    maxHp: 10,
     attack: 2,
     strength: 50,
     defense: 0,
@@ -691,6 +698,7 @@ console.log('big breath mitigation distribution test passed');
 {
   const hero = {
     hp: 10,
+    maxHp: 10,
     attack: 0,
     strength: 0,
     defense: 0,
@@ -712,5 +720,92 @@ console.log('big breath mitigation distribution test passed');
   );
   assert.strictEqual(result.log[0], 'Starting fight against Slime (10 HP).');
   console.log('starting fight log hero HP test passed');
+}
+
+// simulateRepeated reports average time per life in seconds
+{
+  const seq = [0, 0.5, 0.5, 0.5];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 1,
+    maxHp: 1,
+    attack: 0,
+    strength: 0,
+    defense: 0,
+    agility: 0,
+  };
+  const monster = {
+    name: 'Slime',
+    hp: 1,
+    attack: 100,
+    defense: 0,
+    agility: 1,
+    xp: 0,
+  };
+  const result = simulateRepeated(
+    hero,
+    monster,
+    {
+      preBattleTime: 60,
+      postBattleTime: 0,
+      enemyAttackTime: 0,
+      enemySpellTime: 0,
+      enemyBreathTime: 0,
+      enemyDodgeTime: 0,
+      heroAttackTime: 0,
+      heroSpellTime: 0,
+      herbTime: 0,
+      fairyWaterTime: 0,
+      framesBetweenFights: 0,
+    },
+    1,
+  );
+  Math.random = orig;
+  assert(Math.abs(result.averageTimeSeconds - 1) < 1e-9);
+  assert.strictEqual(result.timeFrames, 60);
+  console.log('repeated battle average time test passed');
+}
+
+// simulateBattle preserves hero's max HP between fights
+{
+  const seq = [0, 0, 0, 0, 0, 0.5, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 50,
+    maxHp: 100,
+    attack: 200,
+    strength: 200,
+    defense: 0,
+    agility: 100,
+    mp: 8,
+    spells: ['HEALMORE'],
+  };
+  const monster = {
+    name: 'Slime',
+    hp: 1,
+    attack: 200,
+    defense: 0,
+    agility: 0,
+    xp: 0,
+    dodge: 0,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+  });
+  Math.random = orig;
+  assert(result.log.includes('Hero casts HEALMORE and heals 50 HP.'));
+  assert.strictEqual(result.winner, 'hero');
+  console.log('max HP healing test passed');
 }
 


### PR DESCRIPTION
## Summary
- ensure repeated fights retain hero's maximum HP so healing spells aren't capped by current health
- require explicit hero max HP instead of defaulting to current HP and update tests and samples accordingly
- report total time for repeated battle sequences in minutes and seconds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991bee81b083328fca875e926a8c8e