### PR TITLE
Shorten share URL encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,23 +231,34 @@
     const usePreset = document.getElementById('use-preset');
     const monsterStats = document.getElementById('monster-stats');
     const shareBtn = document.getElementById('share-url');
-    const params = new URLSearchParams(location.search);
-    const encodedData = params.get('d');
+    const fieldIds = Array.from(form.elements)
+      .filter((el) => el.id && el !== shareBtn)
+      .map((el) => el.id);
+    const encodedData = location.hash.slice(1);
+
+    function toBase64Url(str) {
+      return str.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    }
+
+    function fromBase64Url(str) {
+      str = str.replace(/-/g, '+').replace(/_/g, '/');
+      while (str.length % 4) str += '=';
+      return str;
+    }
 
     function getFormData() {
-      const data = {};
-      Array.from(form.elements).forEach((el) => {
-        if (!el.id) return;
-        if (el.type === 'checkbox') data[el.id] = el.checked ? 1 : 0;
-        else data[el.id] = el.value;
+      return fieldIds.map((id) => {
+        const el = document.getElementById(id);
+        if (el.type === 'checkbox') return el.checked ? 1 : 0;
+        return el.value;
       });
-      return data;
     }
 
     function setFormData(data) {
-      Object.entries(data).forEach(([id, val]) => {
+      fieldIds.forEach((id, idx) => {
         const el = document.getElementById(id);
         if (!el) return;
+        const val = data[idx];
         if (el.type === 'checkbox') el.checked = Boolean(Number(val));
         else el.value = val;
       });
@@ -257,10 +268,10 @@
 
     shareBtn.addEventListener('click', () => {
       const data = getFormData();
-      const compressed = LZString.compressToEncodedURIComponent(
-        JSON.stringify(data),
+      const compressed = toBase64Url(
+        LZString.compressToBase64(JSON.stringify(data)),
       );
-      const url = `${location.origin}${location.pathname}?d=${compressed}`;
+      const url = `${location.origin}${location.pathname}#${compressed}`;
       navigator.clipboard.writeText(url).then(() => alert('URL copied'));
     });
 
@@ -309,7 +320,9 @@
           selectedName === 'Golem' ? 'block' : 'none';
         toggleMonsterStats();
         if (encodedData) {
-          const json = LZString.decompressFromEncodedURIComponent(encodedData);
+          const json = LZString.decompressFromBase64(
+            fromBase64Url(encodedData),
+          );
           if (json) setFormData(JSON.parse(json));
         }
       });


### PR DESCRIPTION
## Summary
- Replace share link data object with ordered field array and compress via Base64 URL-safe encoding
- Decode Base64 share data from URL hash instead of query params

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68992e9e8d688332b93fb33fbed902ab