### PR TITLE
Use minimum physical damage for Hurtmore decision

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -241,11 +241,17 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     }
 
     if (best === 'HURTMORE' || best === 'HURT') {
-      const maxPhysicalDamage =
-        hero.attack < monster.defense + 2
-          ? 1
-          : Math.floor(baseMaxDamage(hero.attack, monster.defense));
-      if (maxPhysicalDamage >= monsterHpKnownMax) {
+      let minPhysicalDamage;
+      if (hero.attack < monster.defense + 2) {
+        minPhysicalDamage = 0;
+      } else {
+        // Minimum physical damage when attack succeeds is half of the maximum
+        // damage, rounded down.
+        minPhysicalDamage = Math.floor(
+          baseMaxDamage(hero.attack, monster.defense) / 2,
+        );
+      }
+      if (minPhysicalDamage >= monsterHpKnownMax) {
         best = 'attack';
       }
     }

--- a/tests.js
+++ b/tests.js
@@ -180,7 +180,7 @@ console.log('big breath mitigation distribution test passed');
   console.log('hero first turn order test passed');
 }
 
-// Hero uses a physical attack instead of a second HURTMORE when it can finish the fight
+// Hero casts HURTMORE again when a physical attack cannot guarantee a kill
 {
   const seq = [0, 0, 0, 0.25, 0, 0.5, 0.5, 0.99];
   let i = 0;
@@ -218,10 +218,13 @@ console.log('big breath mitigation distribution test passed');
     enemyDodgeTime: 0,
   });
   Math.random = orig;
-  assert(result.log.includes('Hero attacks for 10 damage.'));
-  assert.strictEqual(result.mpSpent, 5);
+  const hurtmoreCasts = result.log.filter((l) =>
+    l.startsWith('Hero casts HURTMORE'),
+  ).length;
+  assert.strictEqual(hurtmoreCasts, 2);
+  assert.strictEqual(result.mpSpent, 10);
   console.log(
-    'physical attack prioritized over hurtmore after damage dealt test passed',
+    'second hurtmore used when physical attack is not a guaranteed kill test passed',
   );
 }
 


### PR DESCRIPTION
## Summary
- Fix hero AI to only switch to physical attacks when the minimum damage will finish the enemy
- Add regression test ensuring Hurtmore is cast again when a physical attack can't guarantee a kill

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899349795248332aa933ed224594b27