### PR TITLE
Add risk-aware finishing blow logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project provides a lightweight JavaScript simulator inspired by the NES gam
 - Optional consumables: Herbs heal 23–30 HP (150 frames) while Fairy Water deals 9–16 damage (210 frames, 0–1 against Metal Slimes) and both ignore Stopspell.
 - Hero attack is derived from Strength, chosen weapon, and optional gear (Fighter's Ring +2 attack, Death Necklace +10 attack).
 - Hero picks the offensive action (attack, HURT, HURTMORE, or Fairy Water) with the highest expected damage.
+- When the monster's known remaining HP is lower than the potential damage from an attack, the hero will attempt the finishing blow instead of healing. A `dodgeRateRiskFactor` setting (0–1, default 0) lets the hero heal instead when the chance of a dodge or resist exceeds the chosen threshold.
 - Physical attacks have a 1/32 chance to become critical hits dealing 50–100% of attack power and adding 40 frames.
 - When the hero's attack is less than the monster's defense + 2, normal attack damage is replaced with a 50% chance of dealing 0 or 1 damage.
 - Monsters may flee at the start of their turn if the hero's strength is at least twice the monster's attack (25% chance), ending the battle early with a 45-frame message and no experience.

--- a/cli.js
+++ b/cli.js
@@ -49,6 +49,7 @@ const settings = {
   enemyBreathTime: 160,
   enemyDodgeTime: 60,
   framesBetweenFights: 30,
+  dodgeRateRiskFactor: 0,
 };
 
 const {

--- a/simulator.js
+++ b/simulator.js
@@ -122,6 +122,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     enemyDodgeTime = 60,
     preBattleTime = 140,
     postBattleTime = 200,
+    dodgeRateRiskFactor = 0,
   } = settings;
 
   let log = [];
@@ -192,6 +193,55 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     }
 
     if (hero.hp <= currentMaxDamage) {
+      const killOptions = [];
+
+      let maxPhysical;
+      if (hero.attack < monster.defense + 2) {
+        maxPhysical = 1;
+      } else {
+        maxPhysical = Math.floor(baseMaxDamage(hero.attack, monster.defense));
+      }
+      killOptions.push({
+        action: 'attack',
+        max: maxPhysical,
+        fail: (monster.dodge || 0) / 64,
+      });
+
+      if (!hero.stopspelled && hero.spells) {
+        if (
+          hero.spells.includes('HURTMORE') &&
+          hero.mp >= HERO_SPELL_COST.HURTMORE
+        ) {
+          killOptions.push({
+            action: 'HURTMORE',
+            max: 65,
+            fail: monster.hurtResist || 0,
+          });
+        }
+        if (hero.spells.includes('HURT') && hero.mp >= HERO_SPELL_COST.HURT) {
+          killOptions.push({
+            action: 'HURT',
+            max: 16,
+            fail: monster.hurtResist || 0,
+          });
+        }
+      }
+
+      if (hero.fairyWater > 0) {
+        const maxFW = monster.name === 'Metal Slime' ? 1 : 16;
+        const failFW = monster.name === 'Metal Slime' ? 0.5 : 0;
+        killOptions.push({
+          action: 'FAIRY_WATER',
+          max: maxFW,
+          fail: failFW,
+        });
+      }
+
+      const kill = killOptions.find(
+        (o) => o.max >= monsterHpKnownMax && o.fail <= dodgeRateRiskFactor,
+      );
+      if (kill) return kill.action;
+
       if (!hero.stopspelled && hero.spells) {
         if (hero.spells.includes('HEALMORE') && hero.mp >= HERO_SPELL_COST.HEALMORE)
           return 'HEALMORE';

--- a/tests.js
+++ b/tests.js
@@ -228,6 +228,92 @@ console.log('big breath mitigation distribution test passed');
   );
 }
 
+// When low on HP, hero attacks to finish if a killing blow is likely
+{
+  const seq = [0, 0, 0, 0.5, 0.99];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 10,
+    maxHp: 20,
+    attack: 100,
+    strength: 100,
+    defense: 0,
+    agility: 10,
+    mp: 3,
+    spells: ['HEAL'],
+    armor: 'none',
+  };
+  const monster = {
+    name: 'Finisher',
+    hp: 40,
+    maxHp: 40,
+    attack: 120,
+    defense: 0,
+    agility: 10,
+    xp: 0,
+    dodge: 0,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+  });
+  Math.random = orig;
+  assert(result.log[0].startsWith('Hero attacks'));
+  assert.strictEqual(result.winner, 'hero');
+  console.log('hero attacks instead of healing when kill is possible test passed');
+}
+
+// Hero heals instead of risking a high dodge or resist rate
+{
+  const seq = [0, 0, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 10,
+    maxHp: 20,
+    attack: 100,
+    strength: 100,
+    defense: 0,
+    agility: 10,
+    mp: 10,
+    spells: ['HEAL'],
+    armor: 'none',
+  };
+  const monster = {
+    name: 'Dodgy',
+    hp: 40,
+    maxHp: 40,
+    attack: 120,
+    defense: 0,
+    agility: 10,
+    xp: 0,
+    dodge: 15,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+    dodgeRateRiskFactor: 0.1,
+  });
+  Math.random = orig;
+  assert(result.log[0].startsWith('Hero casts HEAL'));
+  console.log('hero heals when attack dodge rate exceeds threshold test passed');
+}
+
 // Hero critical hits deal 50%-100% of attack and have configurable extra time
 {
   const seq = [0, 0, 0.5, 0, 0.5];
@@ -820,7 +906,7 @@ console.log('big breath mitigation distribution test passed');
 
 // simulateBattle preserves hero's max HP between fights
 {
-  const seq = [0, 0, 0, 0, 0, 0.5, 0];
+  const seq = [0, 0, 0, 0, 0.5, 0.5, 0];
   let i = 0;
   const orig = Math.random;
   Math.random = () => seq[i++] ?? 0;
@@ -841,7 +927,7 @@ console.log('big breath mitigation distribution test passed');
     defense: 0,
     agility: 0,
     xp: 0,
-    dodge: 0,
+    dodge: 1,
   };
   const result = simulateBattle(hero, monster, {
     preBattleTime: 0,


### PR DESCRIPTION
## Summary
- Allow simulator to accept a `dodgeRateRiskFactor` setting
- Hero now attempts a finishing blow when the monster's remaining HP is below potential attack damage but heals if dodge/resist chance is above the risk factor
- Document and expose the new setting and add tests for both attack and heal scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689937c04abc8332b4cf58e30a73d6d7