### PR TITLE
Fix hero kill logic ignoring hurtmore resist risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project provides a lightweight JavaScript simulator inspired by the NES gam
 - Optional consumables: Herbs heal 23–30 HP (150 frames) while Fairy Water deals 9–16 damage (210 frames, 0–1 against Metal Slimes) and both ignore Stopspell.
 - Hero attack is derived from Strength, chosen weapon, and optional gear (Fighter's Ring +2 attack, Death Necklace +10 attack).
 - Hero picks the offensive action (attack, HURT, HURTMORE, or Fairy Water) with the highest expected damage.
-- When the monster's known remaining HP is lower than the potential damage from an attack, the hero will attempt the finishing blow instead of healing. A `dodgeRateRiskFactor` setting (0–1, default 0) lets the hero heal instead when the chance of a dodge or resist exceeds the chosen threshold.
+- When the monster's known remaining HP is lower than the potential damage from an attack, the hero will attempt the finishing blow instead of healing. A `dodgeRateRiskFactor` setting (0–1, default 0) lets the hero heal instead when the chance of a dodge or resist exceeds the chosen threshold; the default 0 ignores the risk entirely.
 - Physical attacks have a 1/32 chance to become critical hits dealing 50–100% of attack power and adding 40 frames.
 - When the hero's attack is less than the monster's defense + 2, normal attack damage is replaced with a 50% chance of dealing 0 or 1 damage.
 - Monsters may flee at the start of their turn if the hero's strength is at least twice the monster's attack (25% chance), ending the battle early with a 45-frame message and no experience.

--- a/simulator.js
+++ b/simulator.js
@@ -238,7 +238,9 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
       }
 
       const kill = killOptions.find(
-        (o) => o.max >= monsterHpKnownMax && o.fail <= dodgeRateRiskFactor,
+        (o) =>
+          o.max >= monsterHpKnownMax &&
+          (dodgeRateRiskFactor === 0 || o.fail <= dodgeRateRiskFactor),
       );
       if (kill) return kill.action;
 

--- a/tests.js
+++ b/tests.js
@@ -228,6 +228,58 @@ console.log('big breath mitigation distribution test passed');
   );
 }
 
+// Hero casts HURTMORE again despite resist chance when using default dodge rate risk factor
+{
+  const seq = [0, 0, 0.6, 0, 0.99, 0.6, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 50,
+    maxHp: 100,
+    attack: 10,
+    strength: 0,
+    defense: 0,
+    agility: 10,
+    mp: 16,
+    spells: ['HURTMORE', 'HEALMORE'],
+    armor: 'none',
+  };
+  const monster = {
+    name: 'Resister',
+    hp: 70,
+    maxHp: 70,
+    attack: 80,
+    defense: 0,
+    agility: 0,
+    xp: 0,
+    dodge: 0,
+    hurtResist: 0.5,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+  });
+  Math.random = orig;
+  const hurtmoreCasts = result.log.filter((l) =>
+    l.startsWith('Hero casts HURTMORE'),
+  ).length;
+  const healmoreCasts = result.log.filter((l) =>
+    l.startsWith('Hero casts HEALMORE'),
+  ).length;
+  assert.strictEqual(hurtmoreCasts, 2);
+  assert.strictEqual(healmoreCasts, 0);
+  console.log(
+    'second hurtmore used despite hurt resist when risk factor is default test passed',
+  );
+}
+
 // When low on HP, hero attacks to finish if a killing blow is likely
 {
   const seq = [0, 0, 0, 0.5, 0.99];
@@ -614,7 +666,8 @@ console.log('big breath mitigation distribution test passed');
   };
   const monster = {
     name: 'BadGuy',
-    hp: 1,
+    hp: 2,
+    maxHp: 2,
     attack: 300,
     defense: 0,
     agility: 1,
@@ -677,6 +730,7 @@ console.log('big breath mitigation distribution test passed');
     enemySpellTime: 0,
     enemyBreathTime: 0,
     enemyDodgeTime: 0,
+    dodgeRateRiskFactor: 0.01,
   });
   Math.random = orig;
   assert(result.log.includes('Hero uses an herb and heals 0 HP.'));
@@ -702,6 +756,7 @@ console.log('big breath mitigation distribution test passed');
     enemySpellTime: 0,
     enemyBreathTime: 0,
     enemyDodgeTime: 0,
+    dodgeRateRiskFactor: 0.01,
   });
   Math.random = orig;
   assert.strictEqual(result.timeFrames, 5);
@@ -735,6 +790,7 @@ console.log('big breath mitigation distribution test passed');
     enemySpellTime: 0,
     enemyBreathTime: 0,
     enemyDodgeTime: 0,
+    dodgeRateRiskFactor: 0.01,
   });
   Math.random = orig;
   assert(result.log.some((l) => l.startsWith('Hero casts HEAL')));
@@ -938,6 +994,7 @@ console.log('big breath mitigation distribution test passed');
     enemySpellTime: 0,
     enemyBreathTime: 0,
     enemyDodgeTime: 0,
+    dodgeRateRiskFactor: 0.01,
   });
   Math.random = orig;
   assert(result.log.includes('Hero casts HEALMORE and heals 50 HP.'));


### PR DESCRIPTION
## Summary
- ensure hero attempts finishing blow even if HURTMORE might be resisted when risk factor is 0
- clarify dodgeRateRiskFactor docs and cover behavior with new test
- adjust herb/heal tests for new risk handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68993af78d7c8332ac67b6a3c7314a7c