### PR TITLE
Expose additional timing options

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -55,6 +55,11 @@ const settings = {
   enemyBreathTime: 135,
   enemyDodgeTime: 60,
   framesBetweenFights: 30,
+  ambushTime: 50,
+  monsterFleeTime: 45,
+  sleepTime: 60,
+  fairyFluteTime: 480,
+  stopspellPenaltyTime: 60,
   dodgeRateRiskFactor: 0,
 };
 

--- a/index.html
+++ b/index.html
@@ -186,21 +186,26 @@
       <legend>Simulation Settings</legend>
       <details>
         <summary>Timing Settings (optional)</summary>
-        <label>Hero Attack Time (frames) <input type="number" id="hero-attack-time" value="120" /></label>
-        <label>Hero Spell Time (frames) <input type="number" id="hero-spell-time" value="180" /></label>
-        <label>Critical Hit Time (frames) <input type="number" id="hero-critical-time" value="30" /></label>
-        <label>Herb Use Time (frames) <input type="number" id="herb-time" value="150" /></label>
-        <label>Fairy Water Use Time (frames) <input type="number" id="fairy-water-time" value="220" /></label>
-        <label>Heal Spell Time Between Fights (frames) <input type="number" id="heal-spell-time" value="230" /></label>
-        <label>Enemy Attack Time (frames) <input type="number" id="enemy-attack-time" value="130" /></label>
-        <label>Enemy Hurt Spell Time (frames) <input type="number" id="enemy-hurt-spell-time" value="190" /></label>
-        <label>Enemy Heal Spell Time (frames) <input type="number" id="enemy-heal-spell-time" value="165" /></label>
-        <label>Enemy Other Spell Time (frames) <input type="number" id="enemy-spell-time" value="150" /></label>
-        <label>Enemy Breath Time (frames) <input type="number" id="enemy-breath-time" value="135" /></label>
-        <label>Enemy Dodge Time (frames) <input type="number" id="enemy-dodge-time" value="60" /></label>
-        <label>Pre-Battle Time (frames) <input type="number" id="pre-battle-time" value="140" /></label>
-        <label>Post-Battle Time (frames) <input type="number" id="post-battle-time" value="200" /></label>
-        <label>Between Fights Time (frames) <input type="number" id="frames-between-fights" value="30" /></label>
+        <label>Hero Attack (frames) <input type="number" id="hero-attack-time" value="120" /></label>
+        <label>Hero Spell (frames) <input type="number" id="hero-spell-time" value="180" /></label>
+        <label>Critical Hit (frames) <input type="number" id="hero-critical-time" value="30" /></label>
+        <label>Herb Use (frames) <input type="number" id="herb-time" value="150" /></label>
+        <label>Fairy Water Use (frames) <input type="number" id="fairy-water-time" value="220" /></label>
+        <label>Heal Spell Between Fights (frames) <input type="number" id="heal-spell-time" value="230" /></label>
+        <label>Enemy Attack (frames) <input type="number" id="enemy-attack-time" value="130" /></label>
+        <label>Enemy Hurt Spell (frames) <input type="number" id="enemy-hurt-spell-time" value="190" /></label>
+        <label>Enemy Heal Spell (frames) <input type="number" id="enemy-heal-spell-time" value="165" /></label>
+        <label>Enemy Other Spell (frames) <input type="number" id="enemy-spell-time" value="150" /></label>
+        <label>Enemy Breath (frames) <input type="number" id="enemy-breath-time" value="135" /></label>
+        <label>Enemy Dodge (frames) <input type="number" id="enemy-dodge-time" value="60" /></label>
+        <label>Pre-Battle (frames) <input type="number" id="pre-battle-time" value="140" /></label>
+        <label>Post-Battle (frames) <input type="number" id="post-battle-time" value="200" /></label>
+        <label>Between Fights (frames) <input type="number" id="frames-between-fights" value="30" /></label>
+        <label>Ambush (frames) <input type="number" id="ambush-time" value="50" /></label>
+        <label>Monster Flee (frames) <input type="number" id="monster-flee-time" value="45" /></label>
+        <label>Sleep (frames) <input type="number" id="sleep-time" value="60" /></label>
+        <label>Fairy Flute (frames) <input type="number" id="fairy-flute-time" value="480" /></label>
+        <label>Stopspell Penalty (frames) <input type="number" id="stopspell-penalty" value="60" /></label>
       </details>
       <label>Mode
         <select id="sim-mode">
@@ -401,6 +406,15 @@
         postBattleTime: Number(document.getElementById('post-battle-time').value),
         framesBetweenFights: Number(
           document.getElementById('frames-between-fights').value,
+        ),
+        ambushTime: Number(document.getElementById('ambush-time').value),
+        monsterFleeTime: Number(
+          document.getElementById('monster-flee-time').value,
+        ),
+        sleepTime: Number(document.getElementById('sleep-time').value),
+        fairyFluteTime: Number(document.getElementById('fairy-flute-time').value),
+        stopspellPenaltyTime: Number(
+          document.getElementById('stopspell-penalty').value,
         ),
       };
       const iterations = Number(document.getElementById('iterations').value);

--- a/simulator.js
+++ b/simulator.js
@@ -124,6 +124,11 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     enemySpellTime = 150,
     enemyBreathTime = 135,
     enemyDodgeTime = 60,
+    ambushTime = 50,
+    monsterFleeTime = 45,
+    sleepTime = 60,
+    fairyFluteTime = 480,
+    stopspellPenaltyTime = 60,
     preBattleTime = 140,
     postBattleTime = 200,
     dodgeRateRiskFactor = 0,
@@ -168,11 +173,11 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
   const enemyRoll = monster.agility * 0.25 * Math.floor(Math.random() * 256);
   if (heroRoll < enemyRoll) {
     log.push(`${monster.name} ambushes!`);
-    timeFrames += 50;
+    timeFrames += ambushTime;
     runMonsterTurn();
   }
   if (hero.hp <= 0 || monster.fled) {
-    timeFrames += monster.fled ? 45 : postBattleTime;
+    timeFrames += monster.fled ? monsterFleeTime : postBattleTime;
     const winner = monster.fled ? 'fled' : 'monster';
     const timeSeconds = timeFrames / 60;
     return {
@@ -335,7 +340,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
         hero.asleep = false;
         hero.sleepTurns = 0;
       } else {
-        timeFrames += 60;
+        timeFrames += sleepTime;
         hero.sleepTurns++;
         log.push('Hero is asleep.');
         return;
@@ -346,7 +351,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     if (action === 'FAIRY_FLUTE') {
       monster.asleep = true;
       monster.sleepTurns = 0;
-      timeFrames += 480;
+      timeFrames += fairyFluteTime;
       log.push('Hero plays the Fairy Flute!');
       return;
     }
@@ -466,7 +471,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
   function runMonsterTurn() {
     if (monster.asleep) {
       if (monster.sleepTurns === 0) {
-        timeFrames += 60;
+        timeFrames += sleepTime;
         monster.sleepTurns++;
         log.push(`${monster.name} is asleep.`);
         return;
@@ -476,7 +481,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
         monster.sleepTurns = 0;
         log.push(`${monster.name} wakes up.`);
       } else {
-        timeFrames += 60;
+        timeFrames += sleepTime;
         monster.sleepTurns++;
         log.push(`${monster.name} is asleep.`);
         return;
@@ -502,7 +507,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
       if (useSupport) {
         const frames = getEnemySpellTime(ability);
         if (monster.stopspelled) {
-          timeFrames += frames - 60;
+          timeFrames += frames - stopspellPenaltyTime;
           log.push(
             `${monster.name} tries to cast ${ability.toUpperCase()}, but is stopspelled.`
           );
@@ -551,7 +556,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
         const spell = ability.toUpperCase();
         const frames = getEnemySpellTime(ability);
         if (monster.stopspelled) {
-          timeFrames += frames - 60;
+          timeFrames += frames - stopspellPenaltyTime;
           log.push(`${monster.name} tries to cast ${spell}, but is stopspelled.`);
         } else {
           dmg = castHurtSpell(spell, 0, 'monster');
@@ -596,7 +601,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     if (monster.fled) break;
   }
 
-  timeFrames += monster.fled ? 45 : postBattleTime;
+  timeFrames += monster.fled ? monsterFleeTime : postBattleTime;
   const winner = monster.fled ? 'fled' : hero.hp > 0 ? 'hero' : 'monster';
   const xpGained = winner === 'hero' ? monsterStats.xp : 0;
   const timeSeconds = timeFrames / 60;

--- a/tests.js
+++ b/tests.js
@@ -164,7 +164,8 @@ console.log('big breath mitigation distribution test passed');
   console.log('sleep resist test passed');
 }
 
-// Stopspell prevents enemy spells and shortens their casting time by 60 frames
+// Stopspell prevents enemy spells and shortens their casting time by the
+// configured penalty (60 frames by default)
 {
   const seq = [0, 0, 0.5, 0.3, 0.99, 0.99, 0.5, 0.5, 0.5];
   let i = 0;
@@ -1167,6 +1168,11 @@ const fieldOrder = [
   'pre-battle-time',
   'post-battle-time',
   'frames-between-fights',
+  'ambush-time',
+  'monster-flee-time',
+  'sleep-time',
+  'fairy-flute-time',
+  'stopspell-penalty',
   'sim-mode',
   'iterations',
 ];
@@ -1218,6 +1224,11 @@ const sampleParams = {
   'pre-battle-time': '140',
   'post-battle-time': '200',
   'frames-between-fights': '30',
+  'ambush-time': '50',
+  'monster-flee-time': '45',
+  'sleep-time': '60',
+  'fairy-flute-time': '480',
+  'stopspell-penalty': '60',
   'sim-mode': 'single',
   'iterations': '1000',
 };


### PR DESCRIPTION
## Summary
- simplify timing labels to reference only frames and add controls for ambush, flee, sleep, fairy flute, and stopspell penalty durations
- allow simulator to accept and use these new timing settings instead of hardcoded values
- expand URL parameter tests to cover new timing fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a454a98c88332ad3ea9372d82e395