### PR TITLE
Increase enemy dodge time to 80 frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Visit the simulator at: https://brianwilliams42.github.io/dwrbattlesim/
   - Enemy Heal/Healmore spell: 165 frames
   - Enemy other spell: 170 frames
   - Enemy breath: 135 frames
-  - Enemy dodge: 60 frames when a dodge occurs
+  - Enemy dodge: 80 frames when a dodge occurs (replaces normal attack time)
 - Fixed overhead for battles: 140-frame pre-battle animation and 200-frame post-battle message
 - Monster support abilities (Sleep, Stopspell, Heal, Healmore) with configurable likelihood each turn. Sleep causes the hero to skip turns with a 50% chance to wake starting the second turn; Stopspell can silence hero spellcasting.
 - Monsters can also have an attack ability (HURT: 3–10 dmg, HURTMORE: 30–45 dmg, Small Breath, Big Breath) used with a configurable frequency. Hero armor (None, Magic Armor, Erdrick's Armor) determines mitigation: Magic Armor reduces HURT spells while Erdrick's Armor also mitigates breath attacks and grants Stopspell immunity.

--- a/cli.js
+++ b/cli.js
@@ -53,7 +53,7 @@ const settings = {
   enemyHealSpellTime: 165,
   enemySpellTime: 170,
   enemyBreathTime: 135,
-  enemyDodgeTime: 60,
+  enemyDodgeTime: 80,
   framesBetweenFights: 30,
   ambushTime: 50,
   monsterFleeTime: 45,

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
         <label>Enemy Heal Spell (frames) <input type="number" id="enemy-heal-spell-time" value="165" /></label>
         <label>Enemy Other Spell (frames) <input type="number" id="enemy-spell-time" value="150" /></label>
         <label>Enemy Breath (frames) <input type="number" id="enemy-breath-time" value="135" /></label>
-        <label>Enemy Dodge (frames) <input type="number" id="enemy-dodge-time" value="60" /></label>
+        <label>Enemy Dodge (frames) <input type="number" id="enemy-dodge-time" value="80" /></label>
         <label>Pre-Battle (frames) <input type="number" id="pre-battle-time" value="140" /></label>
         <label>Post-Battle (frames) <input type="number" id="post-battle-time" value="200" /></label>
         <label>Between Fights (frames) <input type="number" id="frames-between-fights" value="30" /></label>

--- a/simulator.js
+++ b/simulator.js
@@ -123,7 +123,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     enemyHealSpellTime = 165,
     enemySpellTime = 150,
     enemyBreathTime = 135,
-    enemyDodgeTime = 60,
+    enemyDodgeTime = 80,
     ambushTime = 50,
     monsterFleeTime = 45,
     sleepTime = 60,
@@ -434,7 +434,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
 
     const dodgeChance = (monster.dodge || 0) / 64;
     if (Math.random() < dodgeChance) {
-      timeFrames += enemyDodgeTime;
+      timeFrames += enemyDodgeTime; // replaces normal attack time
       log.push('Hero attacks, but the monster dodges!');
     } else {
       if (Math.random() < 1 / 32) {

--- a/tests.js
+++ b/tests.js
@@ -1220,7 +1220,7 @@ const sampleParams = {
   'enemy-heal-spell-time': '165',
   'enemy-spell-time': '170',
   'enemy-breath-time': '135',
-  'enemy-dodge-time': '60',
+  'enemy-dodge-time': '80',
   'pre-battle-time': '140',
   'post-battle-time': '200',
   'frames-between-fights': '30',


### PR DESCRIPTION
## Summary
- Raise enemy dodge time to 80 frames and clarify it replaces the hero's attack time when dodging
- Update CLI, web UI, docs, and tests to reflect new dodge timing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a495a40248332acb40fbb2bb32735