### PR TITLE
Add XP/min metric accounting for MP refills

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Visit the simulator at: https://brianwilliams42.github.io/dwrbattlesim/
 - Heroes can cast STOPSPELL to silence enemy spellcasting and SLEEP to incapacitate foes. Success depends on the monster's Stopspell or Sleep resistance (0–15 out of 16). Stopspelled monsters still attempt to cast but their spells fail and cost 165 frames, while sleeping monsters skip their turn with a 33% wake chance starting the second turn.
 - When fighting the Golem, the hero can optionally carry the Fairy Flute. Playing it (470 frames) puts the Golem to sleep for one guaranteed turn and gives it a 33% wake chance on later turns.
 - Computes experience gained, average battle duration, and XP per minute.
-- Repeated fight mode chains battles until the hero dies, allowing healing between fights and reporting total XP per life, XP per minute, enemies defeated, and MP used per fight, with a configurable 30-frame pause between battles.
+- Repeated fight mode chains battles until the hero dies, allowing healing between fights and reporting total XP per life, XP per minute, XP per minute including refill time, enemies defeated, and MP used per fight, with configurable pauses between battles and MP refills.
 - Browser interface for quick experimentation and a CLI example.
 - Web UI includes preset enemy selector with stats and an option to override them; enemy HP is randomized each fight between 75% and 100% of its listed maximum. Timing values default to the NES and Standard Flag speeds but can be tweaked in a hidden advanced section.
 

--- a/cli.js
+++ b/cli.js
@@ -60,6 +60,7 @@ const settings = {
   enemyDodgeTime: 80,
   enemySleepTime: 50,
   framesBetweenFights: 30,
+  refillTimeSeconds: 75,
   ambushTime: 50,
   monsterFleeTime: 100,
   enemyStopspelledSpellTime: 165,
@@ -91,6 +92,9 @@ console.log(
 const repeated = simulateRepeated(hero, monster, settings, 100);
 console.log(`Average XP per life: ${repeated.averageXPPerLife.toFixed(2)}`);
 console.log(`Average XP per minute: ${repeated.averageXPPerMinute.toFixed(2)}`);
+console.log(
+  `Average XP per minute (incl. refill): ${repeated.averageXPPerMinuteWithRefill.toFixed(2)}`,
+);
 console.log(`Average enemies killed per life: ${repeated.averageKills.toFixed(2)}`);
 console.log(`Average MP spent per fight: ${repeated.averageMPPerFight.toFixed(2)}`);
 console.log(`Average time per life: ${formatTime(repeated.averageTimeSeconds)}`);

--- a/index.html
+++ b/index.html
@@ -213,6 +213,7 @@
           <label>Post-Battle <input type="number" id="post-battle-time" value="200" /></label>
       </details>
       <label id="frames-between-fights-label" style="display: none; margin-top:10px">Frames Between Fights <input type="number" id="frames-between-fights" value="30" /></label>
+      <label id="refill-seconds-label" style="display: none; margin-top:10px">Refill Time (sec) <input type="number" id="refill-seconds" value="75" /></label>
       <label>Mode
         <select id="sim-mode">
           <option value="single">Single Battle</option>
@@ -249,6 +250,7 @@
     const monsterStats = document.getElementById('monster-stats');
     const shareBtn = document.getElementById('share-url');
     const betweenFightsLabel = document.getElementById('frames-between-fights-label');
+    const refillSecondsLabel = document.getElementById('refill-seconds-label');
     const simModeSelect = document.getElementById('sim-mode');
     const fieldIds = Array.from(form.elements)
       .filter((el) => el.id && el !== shareBtn)
@@ -325,6 +327,8 @@
 
     function toggleBetweenFights() {
       betweenFightsLabel.style.display =
+        simModeSelect.value === 'repeated' ? 'block' : 'none';
+      refillSecondsLabel.style.display =
         simModeSelect.value === 'repeated' ? 'block' : 'none';
     }
 
@@ -467,6 +471,9 @@
           framesBetweenFights: Number(
             document.getElementById('frames-between-fights').value,
           ),
+          refillTimeSeconds: Number(
+            document.getElementById('refill-seconds').value,
+          ),
           ambushTime: Number(document.getElementById('ambush-time').value),
           monsterFleeTime: Number(
             document.getElementById('monster-flee-time').value,
@@ -496,6 +503,7 @@
         mode === 'repeated'
           ? `Average XP per life: ${summary.averageXPPerLife.toFixed(2)}\n` +
             `Average XP per minute: ${summary.averageXPPerMinute.toFixed(2)}\n` +
+            `Average XP per minute (incl. refill): ${summary.averageXPPerMinuteWithRefill.toFixed(2)}\n` +
             `Average time per life: ${formatTime(summary.averageTimeSeconds)}\n` +
             `Average enemies defeated per life: ${summary.averageKills.toFixed(2)}\n` +
             `Average MP spent per fight: ${summary.averageMPPerFight.toFixed(2)}`

--- a/simulator.js
+++ b/simulator.js
@@ -722,6 +722,7 @@ export function healBetweenFights(hero, monster, settings) {
 }
 
 export function simulateRepeated(heroStats, monsterStats, settings = {}, iterations = 1) {
+  const refillSeconds = settings.refillTimeSeconds ?? 75;
   let totalXP = 0;
   let totalFrames = 0;
   let totalKills = 0;
@@ -803,10 +804,14 @@ export function simulateRepeated(heroStats, monsterStats, settings = {}, iterati
     }
   }
   const averageXPPerMinute = totalFrames === 0 ? 0 : (totalXP * 3600) / totalFrames;
+  const totalFramesWithRefill = totalFrames + refillSeconds * 60 * iterations;
+  const averageXPPerMinuteWithRefill =
+    totalFramesWithRefill === 0 ? 0 : (totalXP * 3600) / totalFramesWithRefill;
   const averageTimeSeconds = totalFrames / iterations / 60;
   return {
     averageXPPerLife: totalXP / iterations,
     averageXPPerMinute,
+    averageXPPerMinuteWithRefill,
     averageTimeSeconds,
     averageKills: totalKills / iterations,
     averageMPPerFight: totalFights === 0 ? 0 : totalMP / totalFights,

--- a/tests.js
+++ b/tests.js
@@ -1148,6 +1148,44 @@ console.log('big breath mitigation distribution test passed');
   console.log('repeated battle average time test passed');
 }
 
+// simulateRepeated reports XP per minute including refill time
+{
+  const hero = {
+    hp: 1,
+    maxHp: 1,
+    attack: 0,
+    strength: 0,
+    defense: 0,
+    agility: 0,
+  };
+  const monster = {
+    name: 'Slime',
+    hp: 1,
+    attack: 100,
+    defense: 0,
+    agility: 1,
+    xp: 1,
+  };
+  const result = simulateRepeated(
+    hero,
+    monster,
+    {
+      preBattleTime: 60,
+      postBattleTime: 0,
+      enemyAttackTime: 0,
+      enemySpellTime: 0,
+      enemyBreathTime: 0,
+      enemyDodgeTime: 0,
+      framesBetweenFights: 0,
+      herbBetweenTime: 0,
+      refillTimeSeconds: 75,
+    },
+    1,
+  );
+  assert.strictEqual(result.averageXPPerMinuteWithRefill, 0);
+  console.log('repeated battle xp/min with refill test passed');
+}
+
 // simulateBattle preserves hero's max HP between fights
 {
   const seq = [0, 0, 0, 0, 0.5, 0.5, 0];
@@ -1256,6 +1294,7 @@ const fieldOrder = [
   'monster-flee-time',
   'post-battle-time',
   'frames-between-fights',
+  'refill-seconds',
   'sim-mode',
   'iterations',
 ];
@@ -1315,6 +1354,7 @@ const sampleParams = {
   'monster-flee-time': '100',
   'post-battle-time': '200',
   'frames-between-fights': '30',
+  'refill-seconds': '75',
   'sim-mode': 'single',
   'iterations': '1000',
 };


### PR DESCRIPTION
## Summary
- allow configuring MP refill time for repeated battles and show XP/min including refills
- surface refill setting in UI and CLI, defaulting to 75 seconds
- document new option and cover in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9ffded5483329241aa707efc3ef1