### PR TITLE
Add REPEL spell and zone enemy tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Visit the simulator at: https://brianwilliams42.github.io/dwrbattlesim/
 ## Features
 - Monster ambushes determined by comparing `hero agility * rand(0-255)` with `enemy agility * 0.25 * rand(0-255)`. If the monster ambushes, it takes a full turn before the hero acts.
 - After any ambush, the hero always acts before the monster each round.
-- Supports hero spells HURT, HURTMORE, HEAL, HEALMORE, STOPSPELL, and SLEEP with per-spell MP costs and enemy resistances.
+- Supports hero spells HURT, HURTMORE, HEAL, HEALMORE, STOPSPELL, SLEEP, and REPEL with per-spell MP costs and enemy resistances.
 - Tracks MP spent by the hero across a battle.
 - Optional consumables: Herbs heal 23–30 HP (130 frames) while Fairy Water or Torches deal 9–16 damage (245 frames, 0–1 against Metal Slimes) and both ignore Stopspell.
 - Hero attack is derived from Strength, chosen weapon, and optional gear (Fighter's Ring +2 attack, Death Necklace +10 attack).

--- a/cli.js
+++ b/cli.js
@@ -13,7 +13,7 @@ const hero = {
   defense: 40,
   agility: 30,
   mp: 50,
-  spells: ['HURT', 'HEAL', 'STOPSPELL', 'SLEEP'],
+  spells: ['HURT', 'HEAL', 'STOPSPELL', 'SLEEP', 'REPEL'],
   armor: 'none',
   fairyFlute: true,
   herbs: 0,

--- a/index.html
+++ b/index.html
@@ -49,11 +49,11 @@
       flex-wrap: wrap;
       gap: 20px;
     }
-    #sim-form,
-    #results {
-      flex: 1 1 400px;
+    #sim-form {
+      flex: 1 1 500px;
     }
     #results {
+      flex: 1 1 400px;
       border: 2px solid #555;
       background-color: #111;
       padding: 15px;
@@ -69,6 +69,27 @@
     }
     #results pre {
       margin: 0;
+    }
+    .zone-tabs {
+      display: flex;
+      gap: 5px;
+      margin-bottom: 10px;
+    }
+    .zone-tab {
+      flex: 1;
+      padding: 5px;
+      border: 2px solid #555;
+      background-color: #222;
+      cursor: pointer;
+      text-align: center;
+    }
+    .zone-tab.active {
+      background-color: #333;
+    }
+    .zone-tab small {
+      display: block;
+      font-size: 10px;
+      margin-top: 2px;
     }
   </style>
 </head>
@@ -132,6 +153,7 @@
       <label><input type="checkbox" id="hero-healmore" /> HEALMORE</label>
       <label><input type="checkbox" id="hero-stopspell" /> STOPSPELL</label>
       <label><input type="checkbox" id="hero-sleep" /> SLEEP</label>
+      <label><input type="checkbox" id="hero-repel" /> REPEL</label>
       <label><input type="checkbox" id="hero-flute" /> Fairy Flute</label>
     </fieldset>
     <fieldset id="monster-config">
@@ -361,11 +383,18 @@
     }
 
     function setupZoneEnemies() {
+      zoneEnemiesContainer.innerHTML =
+        '<div id="zone-enemy-tabs" class="zone-tabs"></div><div id="zone-enemy-panels"></div>';
+      const tabs = document.getElementById('zone-enemy-tabs');
+      const panels = document.getElementById('zone-enemy-panels');
       for (let i = 0; i < 5; i++) {
-        zoneEnemiesContainer.insertAdjacentHTML(
+        tabs.insertAdjacentHTML(
           'beforeend',
-          `<div class="zone-enemy">
-            <h4>Enemy ${i + 1}</h4>
+          `<div class="zone-tab${i === 0 ? ' active' : ''}" id="zone-tab-${i}" data-index="${i}">Enemy ${i + 1}<br><small id="zone-tab-name-${i}"></small></div>`,
+        );
+        panels.insertAdjacentHTML(
+          'beforeend',
+          `<div class="zone-enemy" id="zone-enemy-${i}" style="${i === 0 ? '' : 'display:none'}">
             <label>Enemy <select id="zone-enemy-select-${i}" data-ignore="1"></select></label>
             <label><input type="checkbox" id="zone-use-preset-${i}" data-ignore="1" checked /> Use preset monster stats</label>
             <div id="zone-monster-stats-${i}" style="display:none">
@@ -414,6 +443,8 @@
         const sel = document.getElementById(`zone-enemy-select-${i}`);
         populateEnemySelect(sel);
         sel.value = enemies[0]?.name || '';
+        const tabName = document.getElementById(`zone-tab-name-${i}`);
+        tabName.textContent = sel.value || 'Custom';
         const preset = document.getElementById(`zone-use-preset-${i}`);
         const stats = document.getElementById(`zone-monster-stats-${i}`);
         function toggle() {
@@ -425,6 +456,7 @@
         }
         preset.addEventListener('change', toggle);
         sel.addEventListener('change', () => {
+          tabName.textContent = sel.value || 'Custom';
           if (preset.checked) {
             const chosen = enemies.find((e) => e.name === sel.value);
             if (chosen) setZoneMonsterStats(i, chosen);
@@ -432,6 +464,15 @@
         });
         toggle();
       }
+      tabs.addEventListener('click', (e) => {
+        const tab = e.target.closest('.zone-tab');
+        if (!tab) return;
+        const idx = Number(tab.dataset.index);
+        for (let j = 0; j < 5; j++) {
+          document.getElementById(`zone-enemy-${j}`).style.display = j === idx ? 'block' : 'none';
+          document.getElementById(`zone-tab-${j}`).classList.toggle('active', j === idx);
+        }
+      });
     }
 
     function updateMonsterStats() {
@@ -491,6 +532,7 @@
           ...(document.getElementById('hero-healmore').checked ? ['HEALMORE'] : []),
           ...(document.getElementById('hero-stopspell').checked ? ['STOPSPELL'] : []),
           ...(document.getElementById('hero-sleep').checked ? ['SLEEP'] : []),
+          ...(document.getElementById('hero-repel').checked ? ['REPEL'] : []),
         ],
       };
       const weaponAttack = Number(document.getElementById('hero-weapon').value);

--- a/simulator.js
+++ b/simulator.js
@@ -108,6 +108,7 @@ const HERO_SPELL_COST = {
   HEALMORE: 8,
   STOPSPELL: 2,
   SLEEP: 2,
+  REPEL: 2,
 };
 
 export function simulateBattle(heroStats, monsterStats, settings = {}) {
@@ -832,25 +833,29 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
   let totalXP = 0;
   let totalMP = 0;
   let repelTiles = 0;
-  if (hero.mp >= 2) {
+  const useRepel = hero.spells?.includes('REPEL');
+  if (useRepel && hero.mp >= 2) {
     hero.mp -= 2;
     totalMP += 2;
     totalFrames += repelCastTime;
     repelTiles = 127;
   }
-  while (totalFrames < maxFrames && (hero.mp > 0 || repelTiles > 0)) {
-    if (repelTiles <= 0 && hero.mp >= 2) {
+  while (totalFrames < maxFrames && (useRepel ? hero.mp > 0 || repelTiles > 0 : true)) {
+    if (useRepel && repelTiles <= 0 && hero.mp >= 2) {
       hero.mp -= 2;
       totalMP += 2;
       totalFrames += repelCastTime;
       repelTiles = 127;
     }
     totalFrames += encounterFrames;
-    repelTiles -= encounterRate;
-    let repelActive = repelTiles >= 0;
-    if (!repelActive) repelTiles = 0;
+    let repelActive = false;
+    if (useRepel) {
+      repelTiles -= encounterRate;
+      repelActive = repelTiles >= 0;
+      if (!repelActive) repelTiles = 0;
+    }
     const monsterTemplate = monsters[Math.floor(Math.random() * monsters.length)];
-    if (repelActive && monsterTemplate.attack < hero.defense) {
+    if (useRepel && repelActive && monsterTemplate.attack < hero.defense) {
       continue;
     }
     const hpMax = monsterTemplate.hp;

--- a/tests.js
+++ b/tests.js
@@ -98,7 +98,7 @@ console.log('big breath mitigation distribution test passed');
     defense: 20,
     agility: 10,
     mp: 2,
-    spells: [],
+    spells: ['REPEL'],
     armor: 'none',
   };
   const weak = {


### PR DESCRIPTION
## Summary
- Add REPEL to hero spell options and only skip zone encounters when the hero knows it
- Convert zone enemy list into tabbed panels with wider configuration area
- Document REPEL support and update CLI default spells

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cd09b07f0833289b9a44c7ae8f1d8