### PR TITLE
Add logging for zone grind encounters and repels

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -834,11 +834,13 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
   let totalMP = 0;
   let repelTiles = 0;
   const useRepel = hero.spells?.includes('REPEL');
+  const log = [];
   if (useRepel && hero.mp >= 2) {
     hero.mp -= 2;
     totalMP += 2;
     totalFrames += repelCastTime;
     repelTiles = 127;
+    log.push('Hero casts REPEL.');
   }
   while (totalFrames < maxFrames && (useRepel ? hero.mp > 0 || repelTiles > 0 : true)) {
     if (useRepel && repelTiles <= 0 && hero.mp >= 2) {
@@ -846,6 +848,7 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
       totalMP += 2;
       totalFrames += repelCastTime;
       repelTiles = 127;
+      log.push('Hero casts REPEL.');
     }
     totalFrames += encounterFrames;
     let repelActive = false;
@@ -856,6 +859,7 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
     }
     const monsterTemplate = monsters[Math.floor(Math.random() * monsters.length)];
     if (useRepel && repelActive && monsterTemplate.attack < hero.defense) {
+      log.push(`${monsterTemplate.name} was repelled.`);
       continue;
     }
     const hpMax = monsterTemplate.hp;
@@ -865,7 +869,9 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
       hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
       maxHp: hpMax,
     };
+    log.push(`Encountered ${monster.name}.`);
     const result = simulateBattle(hero, monster, settings);
+    log.push(...result.log);
     totalFrames += result.timeFrames;
     hero.hp = result.heroHp;
     hero.mp -= result.mpSpent;
@@ -883,5 +889,6 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
     xpGained: totalXP,
     mpSpent: totalMP,
     timeFrames: totalFrames,
+    log,
   };
 }

--- a/tests.js
+++ b/tests.js
@@ -85,6 +85,7 @@ console.log('big breath mitigation distribution test passed');
     maxMinutes: 0.1,
   });
   assert(result.xpGained > 0);
+  assert(result.log[0].startsWith('Encountered'));
   console.log('zone grind basic test passed');
 }
 
@@ -123,6 +124,8 @@ console.log('big breath mitigation distribution test passed');
   });
   assert.strictEqual(result.xpGained, 0);
   assert.strictEqual(result.mpSpent, 2);
+  assert.strictEqual(result.log[0], 'Hero casts REPEL.');
+  assert(result.log.includes('Weak was repelled.'));
   console.log('zone grind repel test passed');
 }
 


### PR DESCRIPTION
## Summary
- log REPEL casts, repelled enemies, and explicit encounters in `simulateZone`
- verify zone grind logging with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd8a2f0008332914dc947055a73a8