### PR TITLE
Average zone grind over multiple simulations

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -99,6 +99,13 @@ console.log(`Average enemies killed per life: ${repeated.averageKills.toFixed(2)
 console.log(`Average MP spent per fight: ${repeated.averageMPPerFight.toFixed(2)}`);
 console.log(`Average time per life: ${formatTime(repeated.averageTimeSeconds)}`);
 
-const zone = simulateZone(hero, [monster, monster, monster, monster, monster], 8, settings);
+const zone = simulateZone(
+  hero,
+  [monster, monster, monster, monster, monster],
+  8,
+  settings,
+  1000,
+);
 console.log(`Zone XP per minute: ${zone.xpPerMinute.toFixed(2)}`);
 console.log(`Zone MP per minute: ${zone.mpPerMinute.toFixed(2)}`);
+zone.log.forEach((line) => console.log(line));

--- a/index.html
+++ b/index.html
@@ -665,14 +665,21 @@
         const encounterRate = Number(
           document.getElementById('zone-encounter-rate').value,
         );
-        const summary = simulateZone(hero, zoneMonsters, encounterRate, settings);
+        const summary = simulateZone(
+          hero,
+          zoneMonsters,
+          encounterRate,
+          settings,
+          iterations,
+        );
         metricsEl.textContent =
           `Average XP per minute: ${summary.xpPerMinute.toFixed(2)}\n` +
           `Average MP per minute: ${summary.mpPerMinute.toFixed(2)}`;
         sampleEl.textContent =
           `Total Time: ${formatTime(summary.timeFrames / 60)}\n` +
           `XP Gained: ${summary.xpGained}\n` +
-          `MP Spent: ${summary.mpSpent}`;
+          `MP Spent: ${summary.mpSpent}\n\n` +
+          summary.log.join("\n");
         return;
       }
 

--- a/simulator.js
+++ b/simulator.js
@@ -823,7 +823,7 @@ export function simulateRepeated(heroStats, monsterStats, settings = {}, iterati
     log: sampleLog,
   };
 }
-export function simulateZone(heroStats, monsters, encounterRate = 16, settings = {}) {
+function simulateZoneOnce(heroStats, monsters, encounterRate, settings) {
   const tileFrames = settings.tileFrames ?? 15;
   const repelCastTime = settings.repelTime ?? 200;
   const maxFrames = (settings.maxMinutes ?? 10) * 60 * 60;
@@ -834,11 +834,13 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
   let totalMP = 0;
   let repelTiles = 0;
   const useRepel = hero.spells?.includes('REPEL');
+  const log = [];
   if (useRepel && hero.mp >= 2) {
     hero.mp -= 2;
     totalMP += 2;
     totalFrames += repelCastTime;
     repelTiles = 127;
+    log.push('Hero casts REPEL.');
   }
   while (totalFrames < maxFrames && (useRepel ? hero.mp > 0 || repelTiles > 0 : true)) {
     if (useRepel && repelTiles <= 0 && hero.mp >= 2) {
@@ -846,6 +848,7 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
       totalMP += 2;
       totalFrames += repelCastTime;
       repelTiles = 127;
+      log.push('Hero casts REPEL.');
     }
     totalFrames += encounterFrames;
     let repelActive = false;
@@ -856,6 +859,7 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
     }
     const monsterTemplate = monsters[Math.floor(Math.random() * monsters.length)];
     if (useRepel && repelActive && monsterTemplate.attack < hero.defense) {
+      log.push(`${monsterTemplate.name} was repelled.`);
       continue;
     }
     const hpMax = monsterTemplate.hp;
@@ -865,7 +869,9 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
       hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
       maxHp: hpMax,
     };
+    log.push(`Encountered ${monster.name}.`);
     const result = simulateBattle(hero, monster, settings);
+    log.push(...result.log);
     totalFrames += result.timeFrames;
     hero.hp = result.heroHp;
     hero.mp -= result.mpSpent;
@@ -883,5 +889,44 @@ export function simulateZone(heroStats, monsters, encounterRate = 16, settings =
     xpGained: totalXP,
     mpSpent: totalMP,
     timeFrames: totalFrames,
+    log,
+  };
+}
+
+export function simulateZone(
+  heroStats,
+  monsters,
+  encounterRate = 16,
+  settings = {},
+  iterations = 1,
+) {
+  let totalXP = 0;
+  let totalMP = 0;
+  let totalFrames = 0;
+  let sampleLog = [];
+  let sampleXP = 0;
+  let sampleMP = 0;
+  let sampleFrames = 0;
+  for (let i = 0; i < iterations; i++) {
+    const result = simulateZoneOnce(heroStats, monsters, encounterRate, settings);
+    totalXP += result.xpGained;
+    totalMP += result.mpSpent;
+    totalFrames += result.timeFrames;
+    if (i === 0) {
+      sampleLog = result.log;
+      sampleXP = result.xpGained;
+      sampleMP = result.mpSpent;
+      sampleFrames = result.timeFrames;
+    }
+  }
+  const xpPerMinute = totalFrames === 0 ? 0 : (totalXP * 3600) / totalFrames;
+  const mpPerMinute = totalFrames === 0 ? 0 : (totalMP * 3600) / totalFrames;
+  return {
+    xpPerMinute,
+    mpPerMinute,
+    xpGained: sampleXP,
+    mpSpent: sampleMP,
+    timeFrames: sampleFrames,
+    log: sampleLog,
   };
 }

--- a/tests.js
+++ b/tests.js
@@ -83,8 +83,9 @@ console.log('big breath mitigation distribution test passed');
     enemyBreathTime: 0,
     enemyDodgeTime: 0,
     maxMinutes: 0.1,
-  });
+  }, 2);
   assert(result.xpGained > 0);
+  assert(result.log[0].startsWith('Encountered'));
   console.log('zone grind basic test passed');
 }
 
@@ -123,6 +124,8 @@ console.log('big breath mitigation distribution test passed');
   });
   assert.strictEqual(result.xpGained, 0);
   assert.strictEqual(result.mpSpent, 2);
+  assert.strictEqual(result.log[0], 'Hero casts REPEL.');
+  assert(result.log.includes('Weak was repelled.'));
   console.log('zone grind repel test passed');
 }
 


### PR DESCRIPTION
## Summary
- Support multiple iterations in `simulateZone` and average results
- Run zone grinds over 1000 simulations in CLI and web UI
- Exercise zone simulation averaging in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd8a2f0008332914dc947055a73a8