### PR TITLE
Add hero stats to encounter log

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -922,7 +922,9 @@ function simulateZoneOnce(heroStats, monsters, encounterRate, settings) {
       hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
       maxHp: hpMax,
     };
-    log.push(`Encountered ${monster.name}.`);
+    log.push(
+      `Encountered ${monster.name}. Hero has ${hero.hp} HP and ${hero.mp} MP.`,
+    );
     const result = simulateBattle(hero, monster, settings);
     log.push(...result.log);
     totalFrames += result.timeFrames;

--- a/tests.js
+++ b/tests.js
@@ -86,6 +86,7 @@ console.log('big breath mitigation distribution test passed');
   }, 2);
   assert(result.xpGained > 0);
   assert(result.log[0].startsWith('Encountered'));
+  assert(/Hero has \d+ HP and \d+ MP\./.test(result.log[0]));
   console.log('zone grind basic test passed');
 }
 


### PR DESCRIPTION
## Summary
- Include hero HP and MP in "Encountered" log lines during zone grind simulation
- Test zone grind logs for hero health and magic values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cfb393d80833283698604b8315627