### PR TITLE
Add Dragonlord forms with custom HP randomization and fix zone grind timing

### DIFF
--- a/enemies.json
+++ b/enemies.json
@@ -454,5 +454,30 @@
     "xp": 350,
     "sleepResist": 15,
     "group": 2
+  },
+  {
+    "hp": 100,
+    "name": "Dragonlord 1",
+    "attack": 90,
+    "defense": 65,
+    "agility": 75,
+    "hurtResist": 15,
+    "dodge": 0,
+    "xp": 0,
+    "sleepResist": 15,
+    "group": 4
+  },
+  {
+    "hp": 165,
+    "name": "Dragonlord 2",
+    "attack": 140,
+    "defense": 100,
+    "agility": 200,
+    "hurtResist": 15,
+    "dodge": 0,
+    "xp": 0,
+    "sleepResist": 15,
+    "group": 4,
+    "hpRange": [150, 165]
   }
 ]

--- a/simulator.js
+++ b/simulator.js
@@ -101,6 +101,18 @@ export function maxMonsterDamage(heroStats, monsterStats) {
   return maxDamage;
 }
 
+export function randomizeMonster(monster) {
+  const hpMax = monster.hpRange ? monster.hpRange[1] : monster.hp;
+  const hpMin = monster.hpRange
+    ? monster.hpRange[0]
+    : Math.ceil(hpMax * 0.75);
+  return {
+    ...monster,
+    hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
+    maxHp: hpMax,
+  };
+}
+
 const HERO_SPELL_COST = {
   HURT: 2,
   HURTMORE: 5,
@@ -672,13 +684,7 @@ export function simulateMany(hero, monster, settings = {}, iterations = 1) {
   let totalHerbs = 0;
   let totalFairyWater = 0;
   for (let i = 0; i < iterations; i++) {
-    const hpMax = monster.hp;
-    const hpMin = Math.ceil(hpMax * 0.75);
-    const m = {
-      ...monster,
-      hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
-      maxHp: hpMax,
-    };
+    const m = randomizeMonster(monster);
     const result = simulateBattle(hero, m, settings);
     totalXP += result.xpGained;
     totalFrames += result.timeFrames;
@@ -787,13 +793,7 @@ export function simulateRepeated(heroStats, monsterStats, settings = {}, iterati
     let fairyWatersUsed = 0;
     const lifeLog = [];
     while (hero.hp > 0) {
-      const hpMax = monsterStats.hp;
-      const hpMin = Math.ceil(hpMax * 0.75);
-      const m = {
-        ...monsterStats,
-        hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
-        maxHp: hpMax,
-      };
+      const m = randomizeMonster(monsterStats);
       if (i === 0) {
         lifeLog.push(
           fights === 0
@@ -871,7 +871,7 @@ export function simulateRepeated(heroStats, monsterStats, settings = {}, iterati
   };
 }
 function simulateZoneOnce(heroStats, monsters, encounterRate, settings) {
-  const tileFrames = settings.tileFrames ?? 15;
+  const tileFrames = settings.tileFrames ?? 16;
   const repelCastTime = settings.repelTime ?? 200;
   const maxFrames = (settings.maxMinutes ?? 10) * 60 * 60;
   const encounterFrames = encounterRate * tileFrames;
@@ -915,13 +915,7 @@ function simulateZoneOnce(heroStats, monsters, encounterRate, settings) {
       log.push(`${monsterTemplate.name} was repelled.`);
       continue;
     }
-    const hpMax = monsterTemplate.hp;
-    const hpMin = Math.ceil(hpMax * 0.75);
-    const monster = {
-      ...monsterTemplate,
-      hp: hpMin + Math.floor(Math.random() * (hpMax - hpMin + 1)),
-      maxHp: hpMax,
-    };
+    const monster = randomizeMonster(monsterTemplate);
     log.push(
       `Encountered ${monster.name}. Hero has ${hero.hp} HP and ${hero.mp} MP.`,
     );

--- a/simulator.js
+++ b/simulator.js
@@ -903,13 +903,16 @@ function simulateZoneOnce(heroStats, monsters, encounterRate, settings) {
       repelTiles = 127;
       log.push('Hero casts REPEL.');
     }
-    totalFrames += encounterFrames;
+    const remainingFrames = maxFrames - totalFrames;
+    const walkFrames = Math.min(encounterFrames, remainingFrames);
+    totalFrames += walkFrames;
     let repelActive = false;
     if (useRepel) {
-      repelTiles -= encounterRate;
+      repelTiles -= walkFrames / tileFrames;
       repelActive = repelTiles >= 0;
       if (!repelActive) repelTiles = 0;
     }
+    if (walkFrames < encounterFrames) break;
     const monsterTemplate = monsters[Math.floor(Math.random() * monsters.length)];
     if (useRepel && repelActive && monsterTemplate.attack < hero.defense) {
       log.push(`${monsterTemplate.name} was repelled.`);

--- a/tests.js
+++ b/tests.js
@@ -192,6 +192,37 @@ console.log('big breath mitigation distribution test passed');
   console.log('zone grind repelled step time test passed');
 }
 
+// Zone grind includes partial walking time at grind end
+{
+  const hero = {
+    hp: 10,
+    maxHp: 10,
+    attack: 100,
+    strength: 100,
+    defense: 0,
+    agility: 0,
+    mp: 0,
+    spells: [],
+    armor: 'none',
+  };
+  const monster = { name: 'Slime', hp: 1, attack: 0, defense: 0, agility: 0, xp: 0 };
+  const result = simulateZone(hero, [monster], 1, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+    healSpellTime: 0,
+    framesBetweenFights: 0,
+    tileFrames: 16,
+    maxMinutes: 20 / 3600,
+  });
+  assert(Math.abs(result.timeFrames - 20) < 1e-6);
+  console.log('zone grind leftover walking time test passed');
+}
+
 // Zone grind heals based on strongest monster
 {
   const seq = [0];

--- a/tests.js
+++ b/tests.js
@@ -10,6 +10,7 @@ import {
   healBetweenFights,
   baseMaxDamage,
   simulateZone,
+  randomizeMonster,
 } from './simulator.js';
 import LZString from 'lz-string';
 const { compressToBase64, decompressFromBase64 } = LZString;
@@ -130,6 +131,67 @@ console.log('big breath mitigation distribution test passed');
   console.log('zone grind repel test passed');
 }
 
+// Zone grind counts step time for encounters
+{
+  const hero = {
+    hp: 10,
+    maxHp: 10,
+    attack: 100,
+    strength: 100,
+    defense: 0,
+    agility: 0,
+    mp: 0,
+    spells: [],
+    armor: 'none',
+  };
+  const monster = { name: 'Slime', hp: 1, attack: 0, defense: 0, agility: 0, xp: 0 };
+  const result = simulateZone(hero, [monster], 1, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+    framesBetweenFights: 0,
+    healSpellTime: 0,
+    maxMinutes: 16 / 3600,
+  });
+  assert.strictEqual(result.timeFrames, 16);
+  console.log('zone grind encounter step time test passed');
+}
+
+// Zone grind counts step time for repelled encounters
+{
+  const hero = {
+    hp: 10,
+    maxHp: 10,
+    attack: 0,
+    strength: 0,
+    defense: 20,
+    agility: 0,
+    mp: 2,
+    spells: ['REPEL'],
+    armor: 'none',
+  };
+  const monster = { name: 'Weak', hp: 1, attack: 10, defense: 0, agility: 0, xp: 0 };
+  const result = simulateZone(hero, [monster], 1, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+    framesBetweenFights: 0,
+    repelTime: 0,
+    healSpellTime: 0,
+    maxMinutes: 16 / 3600,
+  });
+  assert.strictEqual(result.timeFrames, 16);
+  console.log('zone grind repelled step time test passed');
+}
+
 // Zone grind heals based on strongest monster
 {
   const seq = [0];
@@ -247,7 +309,67 @@ console.log('big breath mitigation distribution test passed');
   });
   Math.random = orig;
   assert(result.log.includes('Time limit reached.'));
-  console.log('zone grind time limit test passed');
+console.log('zone grind time limit test passed');
+}
+
+// Dragonlord HP randomization
+{
+  const orig = Math.random;
+  Math.random = () => 0;
+  const dl1 = randomizeMonster({
+    name: 'Dragonlord 1',
+    hp: 100,
+    attack: 90,
+    defense: 65,
+    agility: 75,
+    hurtResist: 15,
+    dodge: 0,
+    xp: 0,
+    sleepResist: 15,
+    group: 4,
+  });
+  Math.random = orig;
+  assert.strictEqual(dl1.hp, 75);
+  assert.strictEqual(dl1.maxHp, 100);
+  console.log('Dragonlord 1 HP randomization test passed');
+}
+{
+  const seq = [0, 0.999];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const dl2Min = randomizeMonster({
+    name: 'Dragonlord 2',
+    hp: 165,
+    attack: 140,
+    defense: 100,
+    agility: 200,
+    hurtResist: 15,
+    dodge: 0,
+    xp: 0,
+    sleepResist: 15,
+    group: 4,
+    hpRange: [150, 165],
+  });
+  const dl2Max = randomizeMonster({
+    name: 'Dragonlord 2',
+    hp: 165,
+    attack: 140,
+    defense: 100,
+    agility: 200,
+    hurtResist: 15,
+    dodge: 0,
+    xp: 0,
+    sleepResist: 15,
+    group: 4,
+    hpRange: [150, 165],
+  });
+  Math.random = orig;
+  assert.strictEqual(dl2Min.hp, 150);
+  assert.strictEqual(dl2Min.maxHp, 165);
+  assert.strictEqual(dl2Max.hp, 165);
+  assert.strictEqual(dl2Max.maxHp, 165);
+  console.log('Dragonlord 2 HP randomization test passed');
 }
 
 // Repeated grind ends when MP too low


### PR DESCRIPTION
## Summary
- add Dragonlord 1 and Dragonlord 2 monsters
- implement `randomizeMonster` helper supporting custom HP ranges
- cover Dragonlord HP randomization with unit tests
- fix zone grind step timing to count 16 frames per step and add tests for encounter and repel cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d09946ef883328a0c4f35b5a2e289