### PR TITLE
Support zone grind settings in share URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,11 +311,82 @@
       return str;
     }
 
+    function getZoneFormData() {
+      const zoneMonsters = [];
+      for (let i = 0; i < 5; i++) {
+        const usePreset = document.getElementById(`zone-use-preset-${i}`).checked;
+        const name = document.getElementById(`zone-enemy-select-${i}`).value;
+        const runFrom = document.getElementById(`zone-run-${i}`).checked ? 1 : 0;
+        if (usePreset) {
+          zoneMonsters.push([1, name, runFrom]);
+        } else {
+          zoneMonsters.push([
+            0,
+            name,
+            Number(document.getElementById(`zone-mon-hp-${i}`).value),
+            Number(document.getElementById(`zone-mon-attack-${i}`).value),
+            Number(document.getElementById(`zone-mon-defense-${i}`).value),
+            Number(document.getElementById(`zone-mon-agility-${i}`).value),
+            Number(document.getElementById(`zone-hurt-resist-${i}`).value),
+            Number(document.getElementById(`zone-mon-dodge-${i}`).value),
+            Number(document.getElementById(`zone-mon-xp-${i}`).value),
+            Number(document.getElementById(`zone-stopspell-resist-${i}`).value),
+            Number(document.getElementById(`zone-sleep-resist-${i}`).value),
+            Number(document.getElementById(`zone-mon-group-${i}`).value),
+            document.getElementById(`zone-mon-support-${i}`).value,
+            Number(document.getElementById(`zone-mon-support-chance-${i}`).value),
+            document.getElementById(`zone-mon-attack-ability-${i}`).value,
+            Number(document.getElementById(`zone-mon-attack-chance-${i}`).value),
+            runFrom,
+          ]);
+        }
+      }
+      const encounterRate = Number(
+        document.getElementById('zone-encounter-rate').value,
+      );
+      return [encounterRate, zoneMonsters];
+    }
+
     function getFormData() {
-      return fieldIds.map((id) => {
+      const base = fieldIds.map((id) => {
         const el = document.getElementById(id);
         if (el.type === 'checkbox') return el.checked ? 1 : 0;
         return el.value;
+      });
+      if (simModeSelect.value === 'zone') base.push(getZoneFormData());
+      return base;
+    }
+
+    function setZoneFormData(zoneData) {
+      if (!zoneData) return;
+      const [encounterRate, monsters] = zoneData;
+      document.getElementById('zone-encounter-rate').value = encounterRate;
+      monsters.forEach((m, i) => {
+        const usePreset = m[0] === 1;
+        const sel = document.getElementById(`zone-enemy-select-${i}`);
+        const preset = document.getElementById(`zone-use-preset-${i}`);
+        const run = m[m.length - 1];
+        sel.value = m[1];
+        preset.checked = usePreset;
+        document.getElementById(`zone-run-${i}`).checked = Boolean(run);
+        if (!usePreset) {
+          document.getElementById(`zone-mon-hp-${i}`).value = m[2];
+          document.getElementById(`zone-mon-attack-${i}`).value = m[3];
+          document.getElementById(`zone-mon-defense-${i}`).value = m[4];
+          document.getElementById(`zone-mon-agility-${i}`).value = m[5];
+          document.getElementById(`zone-hurt-resist-${i}`).value = m[6];
+          document.getElementById(`zone-mon-dodge-${i}`).value = m[7];
+          document.getElementById(`zone-mon-xp-${i}`).value = m[8];
+          document.getElementById(`zone-stopspell-resist-${i}`).value = m[9];
+          document.getElementById(`zone-sleep-resist-${i}`).value = m[10];
+          document.getElementById(`zone-mon-group-${i}`).value = m[11];
+          document.getElementById(`zone-mon-support-${i}`).value = m[12];
+          document.getElementById(`zone-mon-support-chance-${i}`).value = m[13];
+          document.getElementById(`zone-mon-attack-ability-${i}`).value = m[14];
+          document.getElementById(`zone-mon-attack-chance-${i}`).value = m[15];
+        }
+        preset.dispatchEvent(new Event('change'));
+        sel.dispatchEvent(new Event('change'));
       });
     }
 
@@ -327,6 +398,7 @@
         if (el.type === 'checkbox') el.checked = Boolean(Number(val));
         else el.value = val;
       });
+      if (data.length > fieldIds.length) setZoneFormData(data[fieldIds.length]);
       toggleMonsterStats();
       enemySelect.dispatchEvent(new Event('change'));
       toggleModeDisplays();

--- a/tests.js
+++ b/tests.js
@@ -1889,3 +1889,36 @@ const fullHumanUrl = `https://example.com/?${humanParams}`;
 console.log(`Full encoded URL length: ${fullEncodedUrl.length}`);
 console.log(`Full human-readable URL length: ${fullHumanUrl.length}`);
 
+// Zone URL encoding round trip test
+{
+  const zoneMonsters = [
+    [1, 'Slime', 0],
+    [
+      0,
+      'Custom',
+      2,
+      5,
+      1,
+      3,
+      0,
+      1,
+      1,
+      0,
+      0,
+      2,
+      '',
+      0.25,
+      '',
+      0.25,
+      0,
+    ],
+  ];
+  const zoneData = [8, zoneMonsters];
+  const dataArrayWithZone = fieldOrder.map((id) => sampleParams[id]);
+  dataArrayWithZone.push(zoneData);
+  const enc = toBase64Url(compressToBase64(JSON.stringify(dataArrayWithZone)));
+  const dec = JSON.parse(decompressFromBase64(fromBase64Url(enc)));
+  assert.deepStrictEqual(dec, dataArrayWithZone);
+  console.log('zone URL encode/decode round trip test passed');
+}
+


### PR DESCRIPTION
## Summary
- include zone grind enemy and encounter settings when generating share URLs
- skip encoding default monster stats to keep URLs compact
- add tests for zone configuration encoding round trip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d1502a8248332abc432350cddf9f3