### PR TITLE
Expose refill time configuration and metrics in zone grinds

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -109,6 +109,11 @@ const zone = simulateZone(
   settings,
   1000,
 );
+console.log(`Zone XP per life: ${zone.averageXPPerLife.toFixed(2)}`);
 console.log(`Zone XP per minute: ${zone.xpPerMinute.toFixed(2)}`);
+console.log(
+  `Zone XP per minute (incl. refill): ${zone.xpPerMinuteWithRefill.toFixed(2)}`,
+);
+console.log(`Zone time per life: ${formatTime(zone.averageTimeSeconds)}`);
 console.log(`Zone MP per minute: ${zone.mpPerMinute.toFixed(2)}`);
 zone.log.forEach((line) => console.log(line));

--- a/index.html
+++ b/index.html
@@ -571,7 +571,8 @@
     function toggleModeDisplays() {
       const mode = simModeSelect.value;
       betweenFightsLabel.style.display = mode === 'repeated' ? 'block' : 'none';
-      refillSecondsLabel.style.display = mode === 'repeated' ? 'block' : 'none';
+      refillSecondsLabel.style.display =
+        mode === 'repeated' || mode === 'zone' ? 'block' : 'none';
       monsterConfig.style.display = mode === 'zone' ? 'none' : 'block';
       zoneConfig.style.display = mode === 'zone' ? 'block' : 'none';
       zoneSettings.style.display = mode === 'zone' ? 'block' : 'none';
@@ -766,7 +767,10 @@
           iterations,
         );
         metricsEl.textContent =
+          `Average XP per life: ${summary.averageXPPerLife.toFixed(2)}\n` +
           `Average XP per minute: ${summary.xpPerMinute.toFixed(2)}\n` +
+          `Average XP per minute (incl. refill): ${summary.xpPerMinuteWithRefill.toFixed(2)}\n` +
+          `Average time per life: ${formatTime(summary.averageTimeSeconds)}\n` +
           `Average MP per minute: ${summary.mpPerMinute.toFixed(2)}`;
         sampleEl.textContent =
           `Total Time: ${formatTime(summary.timeFrames / 60)}\n` +

--- a/simulator.js
+++ b/simulator.js
@@ -985,11 +985,22 @@ export function simulateZone(
       sampleFrames = result.timeFrames;
     }
   }
+  const refillSeconds = settings.refillTimeSeconds ?? 75;
   const xpPerMinute = totalFrames === 0 ? 0 : (totalXP * 3600) / totalFrames;
   const mpPerMinute = totalFrames === 0 ? 0 : (totalMP * 3600) / totalFrames;
+  const totalFramesWithRefill = totalFrames + refillSeconds * 60 * iterations;
+  const xpPerMinuteWithRefill =
+    totalFramesWithRefill === 0
+      ? 0
+      : (totalXP * 3600) / totalFramesWithRefill;
+  const averageXPPerLife = totalXP / iterations;
+  const averageTimeSeconds = totalFrames / iterations / 60;
   return {
     xpPerMinute,
+    xpPerMinuteWithRefill,
     mpPerMinute,
+    averageXPPerLife,
+    averageTimeSeconds,
     xpGained: sampleXP,
     mpSpent: sampleMP,
     timeFrames: sampleFrames,

--- a/tests.js
+++ b/tests.js
@@ -143,6 +143,8 @@ console.log('big breath mitigation distribution test passed');
 
 // Zone grind counts step time for encounters
 {
+  const orig = Math.random;
+  Math.random = () => 0.5;
   const hero = {
     hp: 10,
     maxHp: 10,
@@ -167,6 +169,7 @@ console.log('big breath mitigation distribution test passed');
     healSpellTime: 0,
     maxMinutes: 16 / 3600,
   });
+  Math.random = orig;
   assert.strictEqual(result.timeFrames, 16);
   console.log('zone grind encounter step time test passed');
 }
@@ -389,6 +392,47 @@ console.log('big breath mitigation distribution test passed');
   Math.random = orig;
   assert(result.log.includes('Time limit reached.'));
 console.log('zone grind time limit test passed');
+}
+
+// simulateZone reports averages and XP/min including refill
+{
+  const seq = [0, 0, 0, 0, 0, 0.5, 0.5, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0.5;
+  const hero = {
+    hp: 10,
+    maxHp: 10,
+    attack: 100,
+    strength: 100,
+    defense: 0,
+    agility: 0,
+    mp: 0,
+    spells: [],
+    armor: 'none',
+  };
+  const monster = { name: 'Slime', hp: 1, attack: 0, defense: 0, agility: 0, xp: 1 };
+  const result = simulateZone(hero, [monster], 1, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+    framesBetweenFights: 0,
+    healSpellTime: 0,
+    tileFrames: 1,
+    maxMinutes: 1 / 3600,
+    refillTimeSeconds: 75,
+  });
+  Math.random = orig;
+  const expectedWithRefill = (1 * 3600) / (1 + 75 * 60);
+  assert.strictEqual(result.averageXPPerLife, 1);
+  assert.strictEqual(result.timeFrames, 1);
+  assert(Math.abs(result.averageTimeSeconds - 1 / 60) < 1e-9);
+  assert(Math.abs(result.xpPerMinuteWithRefill - expectedWithRefill) < 1e-9);
+  console.log('zone grind averages and refill test passed');
 }
 
 // Dragonlord HP randomization


### PR DESCRIPTION
## Summary
- Add `refillTimeSeconds` handling to zone grinds and report XP/min with refill, average XP per life, and average time per life
- Show refill time setting in zone grind UI and display new metrics
- Extend CLI and tests for new zone grind metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d1a9931e883328e5fbfcb35743bb6