### PR TITLE
Fix zone grind XP per life metric

### DIFF
--- a/index.html
+++ b/index.html
@@ -766,8 +766,11 @@
           settings,
           iterations,
         );
+        const avgXPPerLife =
+          summary.averageXPPerLife ??
+          (summary.xpPerMinute * summary.averageTimeSeconds) / 60;
         metricsEl.textContent =
-          `Average XP per life: ${summary.averageXPPerLife.toFixed(2)}\n` +
+          `Average XP per life: ${avgXPPerLife.toFixed(2)}\n` +
           `Average XP per minute: ${summary.xpPerMinute.toFixed(2)}\n` +
           `Average XP per minute (incl. refill): ${summary.xpPerMinuteWithRefill.toFixed(2)}\n` +
           `Average time per life: ${formatTime(summary.averageTimeSeconds)}\n` +


### PR DESCRIPTION
## Summary
- Ensure zone grind metrics always display average XP per life
- Derive XP per life from XP/min and time per life when not provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d1ef21e188332a9e425b01affee72