### PR TITLE
feat: allow disabling stopspell per zone monster

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,8 +323,11 @@
         const usePreset = document.getElementById(`zone-use-preset-${i}`).checked;
         const name = document.getElementById(`zone-enemy-select-${i}`).value;
         const runFrom = document.getElementById(`zone-run-${i}`).checked ? 1 : 0;
+        const useStopspell = document.getElementById(`zone-stopspell-${i}`).checked
+          ? 1
+          : 0;
         if (usePreset) {
-          zoneMonsters.push([1, name, runFrom]);
+          zoneMonsters.push([1, name, runFrom, useStopspell]);
         } else {
           zoneMonsters.push([
             0,
@@ -344,6 +347,7 @@
             document.getElementById(`zone-mon-attack-ability-${i}`).value,
             Number(document.getElementById(`zone-mon-attack-chance-${i}`).value),
             runFrom,
+            useStopspell,
           ]);
         }
       }
@@ -371,11 +375,20 @@
         const usePreset = m[0] === 1;
         const sel = document.getElementById(`zone-enemy-select-${i}`);
         const preset = document.getElementById(`zone-use-preset-${i}`);
-        const run = m[m.length - 1];
         sel.value = m[1];
         preset.checked = usePreset;
-        document.getElementById(`zone-run-${i}`).checked = Boolean(run);
-        if (!usePreset) {
+
+        let runFrom = 0;
+        let useStopspell = 1;
+
+        if (usePreset) {
+          // [1, name, runFrom?, useStopspell?]
+          runFrom = m[2] ?? 0;
+          useStopspell = m[3] ?? 1;
+        } else {
+          // [0, name, hp, attack, defense, agility, hurtResist, dodge, xp,
+          //  stopspellResist, sleepResist, group, supportAbility, supportChance,
+          //  attackAbility, attackChance, runFrom?, useStopspell?]
           document.getElementById(`zone-mon-hp-${i}`).value = m[2];
           document.getElementById(`zone-mon-attack-${i}`).value = m[3];
           document.getElementById(`zone-mon-defense-${i}`).value = m[4];
@@ -390,7 +403,14 @@
           document.getElementById(`zone-mon-support-chance-${i}`).value = m[13];
           document.getElementById(`zone-mon-attack-ability-${i}`).value = m[14];
           document.getElementById(`zone-mon-attack-chance-${i}`).value = m[15];
+          runFrom = m[16] ?? 0;
+          useStopspell = m[17] ?? 1;
         }
+
+        document.getElementById(`zone-run-${i}`).checked = Boolean(runFrom);
+        document.getElementById(`zone-stopspell-${i}`).checked = Boolean(
+          useStopspell,
+        );
         preset.dispatchEvent(new Event('change'));
         sel.dispatchEvent(new Event('change'));
       });
@@ -527,6 +547,7 @@
               </select>
             </label>
             <label><input type="checkbox" id="zone-run-${i}" data-ignore="1" /> Run from this enemy</label>
+            <label><input type="checkbox" id="zone-stopspell-${i}" data-ignore="1" checked /> Use stopspell on this enemy</label>
           </div>`,
         );
         const sel = document.getElementById(`zone-enemy-select-${i}`);
@@ -762,6 +783,7 @@
               document.getElementById(`zone-mon-attack-chance-${i}`).value,
             ),
             runFrom: document.getElementById(`zone-run-${i}`).checked,
+            useStopspell: document.getElementById(`zone-stopspell-${i}`).checked,
           });
         }
         const encounterRate = Number(

--- a/simulator.js
+++ b/simulator.js
@@ -315,6 +315,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
       hero.spells.includes('STOPSPELL') &&
       hero.mp >= HERO_SPELL_COST.STOPSPELL &&
       !monster.stopspelled &&
+      monster.useStopspell !== false &&
       (monster.supportAbility ||
         monster.attackAbility === 'hurt' ||
         monster.attackAbility === 'hurtmore') &&

--- a/tests.js
+++ b/tests.js
@@ -806,6 +806,51 @@ console.log('zone grind time limit test passed');
   console.log('stopspell logic test passed');
 }
 
+// Zone monster config can disable hero stopspell usage
+{
+  const orig = Math.random;
+  Math.random = () => 0;
+  const hero = {
+    hp: 10,
+    maxHp: 10,
+    attack: 5,
+    strength: 0,
+    defense: 0,
+    agility: 10,
+    mp: 5,
+    spells: ['STOPSPELL'],
+    armor: 'none',
+  };
+  const monster = {
+    name: 'Mage',
+    hp: 20,
+    attack: 20,
+    defense: 0,
+    agility: 0,
+    xp: 0,
+    supportAbility: 'sleep',
+    supportChance: 1,
+    stopspellResist: 0,
+    useStopspell: false,
+  };
+  const result = simulateZone(hero, [monster], 1, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    heroSleepStopspellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+    framesBetweenFights: 0,
+    maxMinutes: 0.1,
+  });
+  Math.random = orig;
+  assert(!result.log.includes('Hero casts STOPSPELL.'));
+  console.log('zone stopspell toggle test passed');
+}
+
 // Hero always acts before the monster after any ambush check
 {
   const seq = [0.99, 0, 0.5, 0.99, 0];


### PR DESCRIPTION
## Summary
- allow hero to skip using STOPSPELL on specific zone monsters
- add zone configuration checkbox to control STOPSPELL usage
- test that hero respects stopspell setting during zone grind

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dfd355988833294a1403aef435755