### PR TITLE
Reduce enemy damage when hero defense matches attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Visit the simulator at: https://brianwilliams42.github.io/dwrbattlesim/
 - When the monster's known remaining HP is lower than the potential damage from an attack, the hero will attempt the finishing blow instead of healing. A `dodgeRateRiskFactor` setting (0–1, default 0) lets the hero heal instead when the chance of a dodge or resist exceeds the chosen threshold; the default 0 ignores the risk entirely.
 - Physical attacks have a 1/32 chance to become critical hits dealing 50–100% of attack power and adding 30 frames.
 - When the hero's attack is less than the monster's defense + 2, normal attack damage is replaced with a 50% chance of dealing 0 or 1 damage.
+- When the hero's defense is at least the monster's attack, enemy physical attacks deal a random 0 to one-sixth of their attack power.
 - Monsters may flee at the start of their turn if the hero's strength is at least twice the monster's attack (25% chance), ending the battle early with a 100-frame message and no experience.
 - Enemies that act first add a 50-frame delay before their opening move.
 - Enemies have a configurable chance to dodge attacks.

--- a/simulator.js
+++ b/simulator.js
@@ -8,6 +8,10 @@ export function computeDamage(
   rng = Math.random,
   heroAttack = false,
 ) {
+  if (!heroAttack && defense * 2 >= attack) {
+    const max = Math.floor(attack / 6);
+    return Math.floor(rng() * (max + 1));
+  }
   if (heroAttack && attack < defense + 2) {
     return rng() < 0.5 ? 0 : 1;
   }

--- a/tests.js
+++ b/tests.js
@@ -23,7 +23,7 @@ function averageDamage(attack, defense) {
   let total = 0;
   for (let i = 0; i < n; i++) {
     const rng = () => (i + 0.5) / n;
-    total += computeDamage(attack, defense, rng);
+    total += computeDamage(attack, defense, rng, true);
   }
   return total / n;
 }
@@ -42,6 +42,17 @@ console.log('computeDamage average test passed');
   assert.strictEqual(dmgLow, 0);
   assert.strictEqual(dmgHigh, 1);
   console.log('hero weak attack damage test passed');
+}
+
+// When hero defense is at least enemy attack, enemy damage is reduced
+{
+  const attack = 24;
+  const defense = 12; // hero defense is double the value passed
+  const dmgMin = computeDamage(attack, defense, () => 0);
+  const dmgMax = computeDamage(attack, defense, () => 0.999);
+  assert.strictEqual(dmgMin, 0);
+  assert.strictEqual(dmgMax, 4);
+  console.log('enemy weak attack damage test passed');
 }
 
 const counts = {};


### PR DESCRIPTION
## Summary
- cap enemy physical damage to 0–1/6 of its attack when hero defense is at least equal to that attack
- add unit test confirming reduced enemy damage range
- document new damage behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fd057233c8332b7693c2237144362