### PR TITLE
feat: add attack before hurtmore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Visit the simulator at: https://brianwilliams42.github.io/dwrbattlesim/
 - Optional consumables: Herbs heal 23–30 HP (130 frames) while Fairy Water or Torches deal 9–16 damage (245 frames, 0–1 against Metal Slimes) and both ignore Stopspell.
 - Hero attack is derived from Strength, chosen weapon, and optional gear (Fighter's Ring +2 attack, Death Necklace +10 attack).
 - Hero picks the offensive action (attack, HURT, HURTMORE, or Fairy Water) with the highest expected damage.
+- Optional strategy to force the hero to land a physical attack before using HURTMORE.
 - When the monster's known remaining HP is lower than the potential damage from an attack, the hero will attempt the finishing blow instead of healing. A `dodgeRateRiskFactor` setting (0–1, default 0) lets the hero heal instead when the chance of a dodge or resist exceeds the chosen threshold; the default 0 ignores the risk entirely.
 - Physical attacks have a 1/32 chance to become critical hits dealing 50–100% of attack power and adding 30 frames.
 - When the hero's attack is less than the monster's defense + 2, normal attack damage is replaced with a 50% chance of dealing 0 or 1 damage.

--- a/index.html
+++ b/index.html
@@ -204,6 +204,7 @@
           <option value="0.75">75%</option>
         </select>
       </label>
+      <label style="margin-top:10px"><input type="checkbox" id="attack-before-hurtmore" /> Always physical attack successfully before HURTMORE</label>
     </fieldset>
     <fieldset id="zone-config" style="display:none">
       <legend>Zone Enemies</legend>
@@ -746,6 +747,7 @@
           ),
           spellResistThreshold:
             Number(document.getElementById('spell-resist-threshold').value) / 16,
+          attackBeforeHurtmore: document.getElementById('attack-before-hurtmore').checked,
         };
       const iterations = Number(document.getElementById('iterations').value);
       const mode = document.getElementById('sim-mode').value;

--- a/simulator.js
+++ b/simulator.js
@@ -155,6 +155,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     postBattleTime = 200,
     dodgeRateRiskFactor = 0,
     spellResistThreshold = 5 / 16,
+    attackBeforeHurtmore = false,
   } = settings;
 
   let log = [];
@@ -177,6 +178,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     herbs: heroStats.herbs || 0,
     fairyWater: heroStats.fairyWater || 0,
     fled: false,
+    didDamage: false,
   };
   hero.hurtMitigation = armor === 'magic' || armor === 'erdrick';
   hero.breathMitigation = armor === 'erdrick';
@@ -254,7 +256,8 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     ) {
       if (
         hero.spells.includes('HURTMORE') &&
-        hero.mp >= HERO_SPELL_COST.HURTMORE
+        hero.mp >= HERO_SPELL_COST.HURTMORE &&
+        (!attackBeforeHurtmore || hero.didDamage)
       ) {
         killOptions.push({
           action: 'HURTMORE',
@@ -338,7 +341,8 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     ) {
       if (
         hero.spells.includes('HURTMORE') &&
-        hero.mp >= HERO_SPELL_COST.HURTMORE
+        hero.mp >= HERO_SPELL_COST.HURTMORE &&
+        (!attackBeforeHurtmore || hero.didDamage)
       ) {
         const avg = 61.5 * (1 - (monster.hurtResist || 0));
         if (avg > bestDamage) {
@@ -508,12 +512,14 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
         monsterHpKnownMax = Math.max(0, monsterHpKnownMax - dmg);
         timeFrames += heroAttackTime + heroCriticalTime;
         log.push(`Hero performs a critical hit for ${dmg} damage.`);
+        hero.didDamage = true;
       } else {
         const dmg = computeDamage(hero.attack, monster.defense, Math.random, true);
         monster.hp -= dmg;
         monsterHpKnownMax = Math.max(0, monsterHpKnownMax - dmg);
         timeFrames += heroAttackTime;
         log.push(`Hero attacks for ${dmg} damage.`);
+        if (dmg > 0) hero.didDamage = true;
       }
     }
   }

--- a/tests.js
+++ b/tests.js
@@ -167,7 +167,7 @@ console.log('big breath mitigation distribution test passed');
     spells: [],
     armor: 'none',
   };
-  const monster = { name: 'Slime', hp: 1, attack: 0, defense: 0, agility: 0, xp: 0 };
+  const monster = { name: 'Slime', hp: 1, attack: 1, defense: 0, agility: 0, xp: 0 };
   const result = simulateZone(hero, [monster], 1, {
     preBattleTime: 0,
     postBattleTime: 0,
@@ -190,7 +190,7 @@ console.log('big breath mitigation distribution test passed');
   const hero = {
     hp: 10,
     maxHp: 10,
-    attack: 0,
+    attack: 1,
     strength: 0,
     defense: 20,
     agility: 0,
@@ -594,7 +594,7 @@ console.log('zone grind time limit test passed');
   const hero = {
     hp: 10,
     maxHp: 10,
-    attack: 0,
+    attack: 1,
     defense: 0,
     agility: 5,
   };
@@ -1035,6 +1035,52 @@ console.log('zone grind time limit test passed');
   ).length;
   assert.strictEqual(hurtmoreCasts, 0);
   console.log('high hurt resist blocks hero hurtmore test passed');
+}
+
+// Hero attacks until dealing damage before using HURTMORE when option enabled
+{
+  const seq = [0, 0, 0, 0.1, 0.4, 0.5, 0, 0.1, 0.6, 0.5, 0];
+  let i = 0;
+  const orig = Math.random;
+  Math.random = () => seq[i++] ?? 0;
+  const hero = {
+    hp: 100,
+    maxHp: 100,
+    attack: 10,
+    strength: 0,
+    defense: 0,
+    agility: 10,
+    mp: 10,
+    spells: ['HURTMORE'],
+    armor: 'none',
+  };
+  const monster = {
+    name: 'Tank',
+    hp: 59,
+    maxHp: 59,
+    attack: 1,
+    defense: 20,
+    agility: 0,
+    xp: 0,
+    dodge: 0,
+  };
+  const result = simulateBattle(hero, monster, {
+    preBattleTime: 0,
+    postBattleTime: 0,
+    heroAttackTime: 0,
+    heroSpellTime: 0,
+    enemyAttackTime: 0,
+    enemySpellTime: 0,
+    enemyBreathTime: 0,
+    enemyDodgeTime: 0,
+    attackBeforeHurtmore: true,
+  });
+  Math.random = orig;
+  const heroActions = result.log.filter((l) => l.startsWith('Hero'));
+  assert.strictEqual(heroActions[0], 'Hero attacks for 0 damage.');
+  assert.strictEqual(heroActions[1], 'Hero attacks for 1 damage.');
+  assert(heroActions[2].startsWith('Hero casts HURTMORE'));
+  console.log('attack before hurtmore option test passed');
 }
 
 // When low on HP, hero heals if a killing blow is not guaranteed


### PR DESCRIPTION
## Summary
- add "Always physical attack successfully before HURTMORE" checkbox to Monster Stats
- prevent HURTMORE until hero lands a physical hit when the option is enabled
- cover new behavior with tests and documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2116fcdb48332a1bc50f1db2d2f77