### PR TITLE
Ensure hero attacks before casting HURTMORE

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,8 +327,13 @@
         const useStopspell = document.getElementById(`zone-stopspell-${i}`).checked
           ? 1
           : 0;
+        const attackBeforeHurtmore = document.getElementById(
+          `zone-attack-before-hurtmore-${i}`,
+        ).checked
+          ? 1
+          : 0;
         if (usePreset) {
-          zoneMonsters.push([1, name, runFrom, useStopspell]);
+          zoneMonsters.push([1, name, runFrom, useStopspell, attackBeforeHurtmore]);
         } else {
           zoneMonsters.push([
             0,
@@ -349,6 +354,7 @@
             Number(document.getElementById(`zone-mon-attack-chance-${i}`).value),
             runFrom,
             useStopspell,
+            attackBeforeHurtmore,
           ]);
         }
       }
@@ -381,15 +387,17 @@
 
         let runFrom = 0;
         let useStopspell = 1;
+        let attackBeforeHurtmore = 0;
 
         if (usePreset) {
-          // [1, name, runFrom?, useStopspell?]
+          // [1, name, runFrom?, useStopspell?, attackBeforeHurtmore?]
           runFrom = m[2] ?? 0;
           useStopspell = m[3] ?? 1;
+          attackBeforeHurtmore = m[4] ?? 0;
         } else {
           // [0, name, hp, attack, defense, agility, hurtResist, dodge, xp,
           //  stopspellResist, sleepResist, group, supportAbility, supportChance,
-          //  attackAbility, attackChance, runFrom?, useStopspell?]
+          //  attackAbility, attackChance, runFrom?, useStopspell?, attackBeforeHurtmore?]
           document.getElementById(`zone-mon-hp-${i}`).value = m[2];
           document.getElementById(`zone-mon-attack-${i}`).value = m[3];
           document.getElementById(`zone-mon-defense-${i}`).value = m[4];
@@ -406,12 +414,16 @@
           document.getElementById(`zone-mon-attack-chance-${i}`).value = m[15];
           runFrom = m[16] ?? 0;
           useStopspell = m[17] ?? 1;
+          attackBeforeHurtmore = m[18] ?? 0;
         }
 
         document.getElementById(`zone-run-${i}`).checked = Boolean(runFrom);
         document.getElementById(`zone-stopspell-${i}`).checked = Boolean(
           useStopspell,
         );
+        document.getElementById(
+          `zone-attack-before-hurtmore-${i}`,
+        ).checked = Boolean(attackBeforeHurtmore);
         preset.dispatchEvent(new Event('change'));
         sel.dispatchEvent(new Event('change'));
       });
@@ -459,6 +471,9 @@
       document.getElementById('stopspell-resist').value = chosen.stopspellResist ?? 0;
       document.getElementById('sleep-resist').value = chosen.sleepResist ?? 0;
       document.getElementById('mon-group').value = chosen.group ?? 2;
+      document.getElementById('attack-before-hurtmore').checked = Boolean(
+        chosen.attackBeforeHurtmore,
+      );
     }
 
     function setZoneMonsterStats(idx, chosen) {
@@ -472,6 +487,9 @@
       document.getElementById(`zone-stopspell-resist-${idx}`).value = chosen.stopspellResist ?? 0;
       document.getElementById(`zone-sleep-resist-${idx}`).value = chosen.sleepResist ?? 0;
       document.getElementById(`zone-mon-group-${idx}`).value = chosen.group ?? 2;
+      document.getElementById(
+        `zone-attack-before-hurtmore-${idx}`,
+      ).checked = Boolean(chosen.attackBeforeHurtmore);
     }
 
     function populateEnemySelect(sel) {
@@ -549,6 +567,7 @@
             </label>
             <label><input type="checkbox" id="zone-run-${i}" data-ignore="1" /> Run from this enemy</label>
             <label><input type="checkbox" id="zone-stopspell-${i}" data-ignore="1" checked /> Use stopspell on this enemy</label>
+            <label><input type="checkbox" id="zone-attack-before-hurtmore-${i}" data-ignore="1" /> Attack before HURTMORE</label>
           </div>`,
         );
         const sel = document.getElementById(`zone-enemy-select-${i}`);
@@ -669,6 +688,7 @@
         supportChance: Number(document.getElementById('mon-support-chance').value),
         attackAbility: document.getElementById('mon-attack-ability').value,
         attackChance: Number(document.getElementById('mon-attack-chance').value),
+        attackBeforeHurtmore: document.getElementById('attack-before-hurtmore').checked,
       };
         const settings = {
           heroAttackTime: Number(
@@ -747,7 +767,6 @@
           ),
           spellResistThreshold:
             Number(document.getElementById('spell-resist-threshold').value) / 16,
-          attackBeforeHurtmore: document.getElementById('attack-before-hurtmore').checked,
         };
       const iterations = Number(document.getElementById('iterations').value);
       const mode = document.getElementById('sim-mode').value;
@@ -786,6 +805,9 @@
             ),
             runFrom: document.getElementById(`zone-run-${i}`).checked,
             useStopspell: document.getElementById(`zone-stopspell-${i}`).checked,
+            attackBeforeHurtmore: document.getElementById(
+              `zone-attack-before-hurtmore-${i}`,
+            ).checked,
           });
         }
         const encounterRate = Number(

--- a/simulator.js
+++ b/simulator.js
@@ -155,7 +155,6 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     postBattleTime = 200,
     dodgeRateRiskFactor = 0,
     spellResistThreshold = 5 / 16,
-    attackBeforeHurtmore = false,
   } = settings;
 
   let log = [];
@@ -178,7 +177,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     herbs: heroStats.herbs || 0,
     fairyWater: heroStats.fairyWater || 0,
     fled: false,
-    didAttack: false,
+    didDamage: false,
   };
   hero.hurtMitigation = armor === 'magic' || armor === 'erdrick';
   hero.breathMitigation = armor === 'erdrick';
@@ -257,7 +256,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
       if (
         hero.spells.includes('HURTMORE') &&
         hero.mp >= HERO_SPELL_COST.HURTMORE &&
-        (!attackBeforeHurtmore || hero.didAttack)
+        (!monster.attackBeforeHurtmore || hero.didDamage)
       ) {
         killOptions.push({
           action: 'HURTMORE',
@@ -342,7 +341,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
       if (
         hero.spells.includes('HURTMORE') &&
         hero.mp >= HERO_SPELL_COST.HURTMORE &&
-        (!attackBeforeHurtmore || hero.didAttack)
+        (!monster.attackBeforeHurtmore || hero.didDamage)
       ) {
         const avg = 61.5 * (1 - (monster.hurtResist || 0));
         if (avg > bestDamage) {
@@ -500,7 +499,6 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     }
 
     const dodgeChance = (monster.dodge || 0) / 64;
-    hero.didAttack = true;
     if (Math.random() < dodgeChance) {
       timeFrames += enemyDodgeTime; // replaces normal attack time
       log.push('Hero attacks, but the monster dodges!');
@@ -513,12 +511,14 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
         monsterHpKnownMax = Math.max(0, monsterHpKnownMax - dmg);
         timeFrames += heroAttackTime + heroCriticalTime;
         log.push(`Hero performs a critical hit for ${dmg} damage.`);
+        hero.didDamage = true;
       } else {
         const dmg = computeDamage(hero.attack, monster.defense, Math.random, true);
         monster.hp -= dmg;
         monsterHpKnownMax = Math.max(0, monsterHpKnownMax - dmg);
         timeFrames += heroAttackTime;
         log.push(`Hero attacks for ${dmg} damage.`);
+        if (dmg > 0) hero.didDamage = true;
       }
     }
   }

--- a/simulator.js
+++ b/simulator.js
@@ -178,7 +178,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     herbs: heroStats.herbs || 0,
     fairyWater: heroStats.fairyWater || 0,
     fled: false,
-    didDamage: false,
+    didAttack: false,
   };
   hero.hurtMitigation = armor === 'magic' || armor === 'erdrick';
   hero.breathMitigation = armor === 'erdrick';
@@ -257,7 +257,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
       if (
         hero.spells.includes('HURTMORE') &&
         hero.mp >= HERO_SPELL_COST.HURTMORE &&
-        (!attackBeforeHurtmore || hero.didDamage)
+        (!attackBeforeHurtmore || hero.didAttack)
       ) {
         killOptions.push({
           action: 'HURTMORE',
@@ -342,7 +342,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
       if (
         hero.spells.includes('HURTMORE') &&
         hero.mp >= HERO_SPELL_COST.HURTMORE &&
-        (!attackBeforeHurtmore || hero.didDamage)
+        (!attackBeforeHurtmore || hero.didAttack)
       ) {
         const avg = 61.5 * (1 - (monster.hurtResist || 0));
         if (avg > bestDamage) {
@@ -500,6 +500,7 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
     }
 
     const dodgeChance = (monster.dodge || 0) / 64;
+    hero.didAttack = true;
     if (Math.random() < dodgeChance) {
       timeFrames += enemyDodgeTime; // replaces normal attack time
       log.push('Hero attacks, but the monster dodges!');
@@ -512,14 +513,12 @@ export function simulateBattle(heroStats, monsterStats, settings = {}) {
         monsterHpKnownMax = Math.max(0, monsterHpKnownMax - dmg);
         timeFrames += heroAttackTime + heroCriticalTime;
         log.push(`Hero performs a critical hit for ${dmg} damage.`);
-        hero.didDamage = true;
       } else {
         const dmg = computeDamage(hero.attack, monster.defense, Math.random, true);
         monster.hp -= dmg;
         monsterHpKnownMax = Math.max(0, monsterHpKnownMax - dmg);
         timeFrames += heroAttackTime;
         log.push(`Hero attacks for ${dmg} damage.`);
-        if (dmg > 0) hero.didDamage = true;
       }
     }
   }

--- a/tests.js
+++ b/tests.js
@@ -1078,8 +1078,7 @@ console.log('zone grind time limit test passed');
   Math.random = orig;
   const heroActions = result.log.filter((l) => l.startsWith('Hero'));
   assert.strictEqual(heroActions[0], 'Hero attacks for 0 damage.');
-  assert.strictEqual(heroActions[1], 'Hero attacks for 1 damage.');
-  assert(heroActions[2].startsWith('Hero casts HURTMORE'));
+  assert(heroActions[1].startsWith('Hero casts HURTMORE'));
   console.log('attack before hurtmore option test passed');
 }
 

--- a/tests.js
+++ b/tests.js
@@ -1063,6 +1063,7 @@ console.log('zone grind time limit test passed');
     agility: 0,
     xp: 0,
     dodge: 0,
+    attackBeforeHurtmore: true,
   };
   const result = simulateBattle(hero, monster, {
     preBattleTime: 0,
@@ -1073,12 +1074,12 @@ console.log('zone grind time limit test passed');
     enemySpellTime: 0,
     enemyBreathTime: 0,
     enemyDodgeTime: 0,
-    attackBeforeHurtmore: true,
   });
   Math.random = orig;
   const heroActions = result.log.filter((l) => l.startsWith('Hero'));
   assert.strictEqual(heroActions[0], 'Hero attacks for 0 damage.');
-  assert(heroActions[1].startsWith('Hero casts HURTMORE'));
+  assert.strictEqual(heroActions[1], 'Hero attacks for 1 damage.');
+  assert(heroActions[2].startsWith('Hero casts HURTMORE'));
   console.log('attack before hurtmore option test passed');
 }
 


### PR DESCRIPTION
## Summary
- Track whether the hero has attempted a physical attack and block HURTMORE until an attack happens
- Update tests for attack-before-HURTMORE behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21523da6c8332beaa798396ed6e96